### PR TITLE
feat: add nextjs best practices skill

### DIFF
--- a/skills/sanity-nextjs-best-practices/SKILL.md
+++ b/skills/sanity-nextjs-best-practices/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: sanity-nextjs-best-practices
+description: Next.js integration patterns for Sanity including data fetching (App Router & Pages Router), Visual Editing, TypeGen, images, page builders, and SEO. Use when building Next.js applications with Sanity CMS.
+license: MIT
+metadata:
+  author: sanity
+  version: "1.0.0"
+---
+
+# Sanity + Next.js Best Practices
+
+Comprehensive patterns for building Next.js applications with Sanity CMS. Covers both App Router (Next.js 13+) and Pages Router patterns, with emphasis on type safety, Visual Editing, and performance.
+
+## When to Apply
+
+Reference these guidelines when:
+- Setting up a new Next.js + Sanity project
+- Implementing data fetching with `defineLive` or `getStaticProps`
+- Configuring Visual Editing and the Presentation Tool
+- Setting up TypeGen for type-safe queries
+- Building reusable image components with `next/image`
+- Creating Page Builder block rendering
+- Implementing SEO metadata and sitemaps
+
+## Architecture Options
+
+### Embedded Studio (Recommended)
+Studio lives inside your Next.js app at `/app/studio/[[...tool]]/page.tsx`.
+
+```
+your-project/
+├── src/
+│   ├── app/
+│   │   └── studio/[[...tool]]/   # Embedded Studio
+│   └── sanity/
+│       ├── lib/
+│       │   ├── client.ts
+│       │   ├── live.ts
+│       │   └── queries.ts
+│       └── schemaTypes/
+├── sanity.config.ts
+└── sanity-typegen.json
+```
+
+### Monorepo (Alternative)
+Studio and Next.js in separate packages. Requires CORS configuration.
+
+```
+your-project/
+├── apps/
+│   ├── studio/     # Sanity Studio
+│   └── web/        # Next.js frontend
+└── pnpm-workspace.yaml
+```
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Rule Files |
+|----------|----------|--------|------------|
+| 1 | Data Fetching | CRITICAL | `data-fetching-app-router.md`, `data-fetching-pages-router.md` |
+| 2 | Visual Editing | HIGH | `visual-editing-setup.md`, `visual-editing-stega.md`, `visual-editing-presentation-queries.md` |
+| 3 | TypeGen | HIGH | `typegen-workflow.md` |
+| 4 | Images | MEDIUM | `images-nextjs.md` |
+| 5 | Page Builder | MEDIUM | `page-builder-nextjs.md` |
+| 6 | SEO | MEDIUM | `seo-metadata.md`, `seo-sitemap-og.md` |
+
+## Quick Start Checklist
+
+### App Router (Next.js 13+)
+
+1. **Install dependencies**
+   ```bash
+   npm install next-sanity @sanity/image-url
+   ```
+
+2. **Set up client** (`src/sanity/lib/client.ts`)
+   ```typescript
+   import { createClient } from 'next-sanity'
+   
+   export const client = createClient({
+     projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+     dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+     apiVersion: '2024-01-01',
+     useCdn: true,
+   })
+   ```
+
+3. **Set up defineLive** (`src/sanity/lib/live.ts`)
+   ```typescript
+   import { defineLive } from 'next-sanity/live'
+   import { client } from './client'
+   
+   export const { sanityFetch, SanityLive } = defineLive({
+     client: client.withConfig({ apiVersion: '2025-01-26' }),
+     serverToken: process.env.SANITY_API_READ_TOKEN,
+     browserToken: process.env.SANITY_API_READ_TOKEN,
+   })
+   ```
+
+4. **Add SanityLive to layout** (`src/app/layout.tsx`)
+   ```typescript
+   import { SanityLive } from '@/sanity/lib/live'
+   
+   export default function RootLayout({ children }) {
+     return (
+       <html>
+         <body>
+           {children}
+           <SanityLive />
+         </body>
+       </html>
+     )
+   }
+   ```
+
+5. **Run TypeGen after schema changes**
+   ```bash
+   npm run typegen
+   ```
+
+### Pages Router
+
+1. **Set up client with preview support**
+2. **Configure `getStaticProps` with ISR**
+3. **Set up Preview Mode API routes**
+4. **Add preview toggle component**
+
+See `rules/data-fetching-pages-router.md` for complete setup.
+
+## App Router vs Pages Router
+
+| Feature | App Router | Pages Router |
+|---------|------------|--------------|
+| Data fetching | `defineLive`, `sanityFetch` | `getStaticProps`, `getServerSideProps` |
+| Preview/Draft | Draft Mode + `VisualEditing` | Preview Mode + custom component |
+| Revalidation | Tag-based, path-based, time-based | ISR with `revalidate` |
+| Real-time | Built into `defineLive` | Manual subscription setup |
+| Recommended for | New projects | Legacy/migration |
+
+## How to Use These Rules
+
+Read individual rule files for detailed explanations and code examples:
+
+```
+rules/data-fetching-app-router.md
+rules/visual-editing-setup.md
+rules/typegen-workflow.md
+```
+
+Each rule file contains:
+- Brief explanation of why it matters
+- Incorrect code example with explanation
+- Correct code example with explanation
+- Additional context and edge cases

--- a/skills/sanity-nextjs-best-practices/rules/_sections.md
+++ b/skills/sanity-nextjs-best-practices/rules/_sections.md
@@ -1,0 +1,36 @@
+# Section Definitions
+
+This file defines the rule categories for Sanity + Next.js best practices. Rules are automatically assigned to sections based on their filename prefix.
+
+---
+
+## 1. Data Fetching (data-)
+Query patterns, caching strategies, and revalidation for both App Router and Pages Router. The foundation for all Sanity + Next.js applications.
+
+**App Router:** `defineLive`, `sanityFetch`, tag-based revalidation, webhooks
+**Pages Router:** `getStaticProps`, `getServerSideProps`, ISR, Preview Mode
+
+## 2. Visual Editing (visual-)
+Presentation Tool setup, Content Source Maps (Stega), draft mode, and click-to-edit overlays. Critical for editor experience.
+
+**Key concepts:** Draft Mode, `VisualEditing` component, `stegaClean`, presentation queries
+
+## 3. TypeGen (typegen-)
+Type generation from schema and GROQ queries. Ensures type safety across the entire application.
+
+**Key concepts:** `defineQuery`, `sanity typegen generate`, result type inference
+
+## 4. Images (images-)
+Image handling with `next/image`, Sanity URL builder, LQIP placeholders, and hotspot support.
+
+**Key concepts:** `urlFor`, `SanityImage` component, blur placeholders, responsive images
+
+## 5. Page Builder (page-)
+Block-based page composition, component rendering patterns, and TypeScript typing for flexible layouts.
+
+**Key concepts:** Switch rendering, `Extract` type pattern, `_key` for React keys
+
+## 6. SEO (seo-)
+Metadata generation, sitemaps, Open Graph images, and search engine optimization patterns.
+
+**Key concepts:** `generateMetadata`, `stega: false`, dynamic sitemaps, canonical URLs

--- a/skills/sanity-nextjs-best-practices/rules/data-fetching-app-router.md
+++ b/skills/sanity-nextjs-best-practices/rules/data-fetching-app-router.md
@@ -1,0 +1,288 @@
+---
+title: App Router Data Fetching with defineLive
+description: Use defineLive for real-time content updates and Visual Editing in Next.js App Router
+tags: nextjs, app-router, data-fetching, defineLive, caching, revalidation
+---
+
+## App Router Data Fetching with defineLive
+
+The `defineLive` function from `next-sanity` (v11+) is the recommended way to fetch Sanity content in Next.js App Router. It handles real-time updates, Visual Editing, and caching automatically.
+
+### Basic Setup
+
+**1. Create the live configuration (`src/sanity/lib/live.ts`):**
+
+```typescript
+import { defineLive } from 'next-sanity/live'
+import { client } from './client'
+
+export const { sanityFetch, SanityLive } = defineLive({
+  client: client.withConfig({ apiVersion: '2025-01-26' }),
+  serverToken: process.env.SANITY_API_READ_TOKEN,
+  browserToken: process.env.SANITY_API_READ_TOKEN,
+})
+```
+
+**2. Add SanityLive to root layout (`src/app/layout.tsx`):**
+
+```typescript
+import { SanityLive } from '@/sanity/lib/live'
+import { VisualEditing } from 'next-sanity/visual-editing'
+import { draftMode } from 'next/headers'
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <SanityLive />
+        {(await draftMode()).isEnabled && <VisualEditing />}
+      </body>
+    </html>
+  )
+}
+```
+
+**3. Fetch data in pages/components:**
+
+```typescript
+import { sanityFetch } from '@/sanity/lib/live'
+import { defineQuery } from 'next-sanity'
+
+const POSTS_QUERY = defineQuery(`*[_type == "post"] | order(publishedAt desc)[0...10]{
+  _id, title, "slug": slug.current, publishedAt
+}`)
+
+export default async function BlogPage() {
+  const { data: posts } = await sanityFetch({ query: POSTS_QUERY })
+  
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post._id}>{post.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+### Caching Strategies
+
+**Prefer `defineLive` by default.** It handles caching and invalidation automatically. Only use manual caching when you need fine-grained control.
+
+| Scenario | Approach |
+|----------|----------|
+| Real-time updates, Visual Editing | `defineLive` (default) |
+| Static marketing pages | Time-based revalidation |
+| Blog posts, products | Tag-based revalidation |
+| Critical accuracy (prices) | Path-based + short revalidation |
+
+### Manual sanityFetch Helper (Advanced)
+
+For manual caching control, create a wrapper:
+
+```typescript
+// src/sanity/lib/fetch.ts
+import { client } from './client'
+import type { QueryParams } from 'next-sanity'
+
+export async function sanityFetch<const QueryString extends string>({
+  query,
+  params = {},
+  revalidate = 60,
+  tags = [],
+}: {
+  query: QueryString
+  params?: QueryParams
+  revalidate?: number | false
+  tags?: string[]
+}) {
+  return client.fetch(query, params, {
+    next: {
+      revalidate: tags.length ? false : revalidate,
+      tags,
+    },
+  })
+}
+```
+
+### Time-Based Revalidation
+
+Simple and predictable. Good for content that changes infrequently.
+
+```typescript
+const posts = await sanityFetch({
+  query: POSTS_QUERY,
+  revalidate: 3600, // Revalidate every hour
+})
+```
+
+### Tag-Based Revalidation
+
+"Update once, revalidate everywhere" - best for referenced content.
+
+**1. Tag your queries:**
+
+```typescript
+const posts = await sanityFetch({
+  query: POSTS_QUERY,
+  tags: ['post', 'author', 'category'],
+})
+
+const post = await sanityFetch({
+  query: POST_QUERY,
+  params,
+  tags: [`post:${params.slug}`, 'author', 'category'],
+})
+```
+
+**2. Create webhook API route (`src/app/api/revalidate/tag/route.ts`):**
+
+```typescript
+import { revalidateTag } from 'next/cache'
+import { type NextRequest, NextResponse } from 'next/server'
+import { parseBody } from 'next-sanity/webhook'
+
+type WebhookPayload = { tags: string[] }
+
+export async function POST(req: NextRequest) {
+  try {
+    const { isValidSignature, body } = await parseBody<WebhookPayload>(
+      req,
+      process.env.SANITY_REVALIDATE_SECRET,
+      true // Add delay to allow CDN to update
+    )
+
+    if (!isValidSignature) {
+      return new Response('Invalid signature', { status: 401 })
+    }
+    if (!Array.isArray(body?.tags) || !body.tags.length) {
+      return new Response('Missing tags', { status: 400 })
+    }
+
+    body.tags.forEach((tag) => revalidateTag(tag))
+    return NextResponse.json({ revalidated: body.tags })
+  } catch (err) {
+    return new Response((err as Error).message, { status: 500 })
+  }
+}
+```
+
+**3. Create GROQ-Powered Webhook in Sanity:**
+- URL: `https://yoursite.com/api/revalidate/tag`
+- Filter: `_type in ["post", "author", "category"]`
+- Projection: `{ "tags": [_type, _type + ":" + slug.current] }`
+
+### Path-Based Revalidation
+
+Surgically revalidate specific routes when documents change.
+
+```typescript
+// src/app/api/revalidate/path/route.ts
+import { revalidatePath } from 'next/cache'
+import { type NextRequest, NextResponse } from 'next/server'
+import { parseBody } from 'next-sanity/webhook'
+
+type WebhookPayload = { path?: string }
+
+export async function POST(req: NextRequest) {
+  try {
+    const { isValidSignature, body } = await parseBody<WebhookPayload>(
+      req,
+      process.env.SANITY_REVALIDATE_SECRET,
+      true
+    )
+
+    if (!isValidSignature) {
+      return new Response('Invalid signature', { status: 401 })
+    }
+    if (!body?.path) {
+      return new Response('Missing path', { status: 400 })
+    }
+
+    revalidatePath(body.path)
+    return NextResponse.json({ revalidated: body.path })
+  } catch (err) {
+    return new Response((err as Error).message, { status: 500 })
+  }
+}
+```
+
+### Sanity CDN vs API
+
+| Setting | Speed | Freshness | Use When |
+|---------|-------|-----------|----------|
+| `useCdn: true` | Fast | May have brief delay | Default for runtime fetches |
+| `useCdn: false` | Slower | Guaranteed fresh | `generateStaticParams`, webhooks |
+
+Override per-request for static generation:
+
+```typescript
+export async function generateStaticParams() {
+  const slugs = await client
+    .withConfig({ useCdn: false })
+    .fetch(SLUGS_QUERY)
+  return slugs
+}
+```
+
+### Debugging: Enable Fetch Logging
+
+```typescript
+// next.config.ts
+const nextConfig: NextConfig = {
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
+}
+```
+
+Console output shows cache status:
+```
+GET /posts 200 in 39ms
+ | GET https://...apicdn.sanity.io/... 200 in 5ms (cache hit)
+```
+
+### Stale Data After Webhook?
+
+Webhooks fire *before* Sanity CDN updates. If you see stale data:
+
+1. **Add delay** - Pass `true` as third arg to `parseBody`
+2. **Or bypass CDN** - Set `useCdn: false` (use sparingly)
+
+### Pagination Pattern
+
+```typescript
+const ARTICLES_QUERY = defineQuery(`
+  *[_type == "article" && defined(slug.current)] 
+  | order(date desc) [$start...$end] {
+    _id, title, "slug": slug.current, date
+  }
+`)
+
+const ARTICLES_COUNT_QUERY = defineQuery(`
+  count(*[_type == "article" && defined(slug.current)])
+`)
+
+export default async function BlogPage({ 
+  searchParams 
+}: { 
+  searchParams: Promise<{ page?: string }> 
+}) {
+  const { page: pageParam } = await searchParams
+  const page = parseInt(pageParam || "1")
+  const start = (page - 1) * 10
+  const end = start + 10
+
+  const [{ data: articles }, { data: total }] = await Promise.all([
+    sanityFetch({ query: ARTICLES_QUERY, params: { start, end } }),
+    sanityFetch({ query: ARTICLES_COUNT_QUERY })
+  ])
+
+  return <ArticleList articles={articles} total={total} page={page} />
+}
+```
+
+Reference: [next-sanity documentation](https://github.com/sanity-io/next-sanity)

--- a/skills/sanity-nextjs-best-practices/rules/data-fetching-pages-router.md
+++ b/skills/sanity-nextjs-best-practices/rules/data-fetching-pages-router.md
@@ -1,0 +1,374 @@
+---
+title: Pages Router Data Fetching
+description: Patterns for getStaticProps, ISR, and Preview Mode in Next.js Pages Router
+tags: nextjs, pages-router, data-fetching, getStaticProps, ISR, preview-mode
+---
+
+## Pages Router Data Fetching
+
+For Next.js Pages Router projects, use `getStaticProps` with ISR (Incremental Static Regeneration) and Preview Mode for draft content.
+
+### Client Setup
+
+```typescript
+// src/sanity/lib/client.ts
+import { createClient } from 'next-sanity'
+
+const config = {
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  apiVersion: '2024-01-01',
+  useCdn: process.env.NODE_ENV === 'production',
+}
+
+export const client = createClient(config)
+
+// Preview client with token (server-side only)
+export const previewClient = createClient({
+  ...config,
+  useCdn: false,
+  token: process.env.SANITY_API_READ_TOKEN,
+})
+
+// Helper to get appropriate client
+export const getClient = (preview?: boolean) => 
+  preview ? previewClient : client
+```
+
+### Basic getStaticProps Pattern
+
+```typescript
+// pages/blog/[slug].tsx
+import { client, getClient } from '@/sanity/lib/client'
+import { defineQuery } from 'groq'
+
+const POST_QUERY = defineQuery(`
+  *[_type == "post" && slug.current == $slug][0]{
+    _id,
+    title,
+    body,
+    "slug": slug.current,
+    publishedAt,
+    author->{ name, image }
+  }
+`)
+
+const SLUGS_QUERY = defineQuery(`
+  *[_type == "post" && defined(slug.current)][].slug.current
+`)
+
+export async function getStaticPaths() {
+  const slugs = await client.fetch(SLUGS_QUERY)
+  
+  return {
+    paths: slugs.map((slug: string) => ({ params: { slug } })),
+    fallback: 'blocking', // Generate new pages on-demand
+  }
+}
+
+export async function getStaticProps({ params, preview = false }) {
+  const post = await getClient(preview).fetch(POST_QUERY, { 
+    slug: params.slug 
+  })
+
+  if (!post) {
+    return { notFound: true }
+  }
+
+  return {
+    props: { post, preview },
+    revalidate: 60, // ISR: revalidate every 60 seconds
+  }
+}
+
+export default function PostPage({ post, preview }) {
+  return (
+    <>
+      {preview && <PreviewBanner />}
+      <article>
+        <h1>{post.title}</h1>
+        {/* ... */}
+      </article>
+    </>
+  )
+}
+```
+
+### ISR (Incremental Static Regeneration)
+
+ISR allows you to update static pages after deployment without rebuilding the entire site.
+
+```typescript
+export async function getStaticProps({ params }) {
+  const data = await client.fetch(QUERY, params)
+
+  return {
+    props: { data },
+    revalidate: 60, // Revalidate at most every 60 seconds
+  }
+}
+```
+
+**ISR strategies:**
+
+| Content Type | Revalidate | Rationale |
+|--------------|------------|-----------|
+| Homepage | 60 | Frequently updated, should feel fresh |
+| Blog posts | 300 | Updates less often, 5 min acceptable |
+| Legal pages | 3600 | Rarely changes, 1 hour fine |
+| Product pages | 60 | Prices/stock may change |
+
+### On-Demand Revalidation
+
+Trigger revalidation via webhook when content changes in Sanity.
+
+**API Route (`pages/api/revalidate.ts`):**
+
+```typescript
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { isValidSignature, SIGNATURE_HEADER_NAME } from '@sanity/webhook'
+
+const secret = process.env.SANITY_REVALIDATE_SECRET!
+
+type SanityWebhookBody = {
+  _type: string
+  slug?: { current: string }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  const signature = req.headers[SIGNATURE_HEADER_NAME] as string
+  const body = await readBody(req)
+
+  if (!isValidSignature(body, signature, secret)) {
+    return res.status(401).json({ message: 'Invalid signature' })
+  }
+
+  const { _type, slug } = JSON.parse(body) as SanityWebhookBody
+
+  try {
+    // Revalidate specific paths based on document type
+    if (_type === 'post' && slug?.current) {
+      await res.revalidate(`/blog/${slug.current}`)
+      await res.revalidate('/blog') // Also revalidate listing
+    }
+    
+    if (_type === 'page' && slug?.current) {
+      await res.revalidate(`/${slug.current}`)
+    }
+
+    // Always revalidate homepage
+    await res.revalidate('/')
+
+    return res.json({ revalidated: true })
+  } catch (err) {
+    return res.status(500).json({ message: 'Error revalidating' })
+  }
+}
+
+// Helper to read raw body
+async function readBody(req: NextApiRequest): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+export const config = {
+  api: { bodyParser: false },
+}
+```
+
+### Preview Mode Setup
+
+Preview Mode lets editors see draft content before publishing.
+
+**1. Enable Preview API Route (`pages/api/preview.ts`):**
+
+```typescript
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { previewClient } from '@/sanity/lib/client'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { secret, slug, type } = req.query
+
+  // Validate secret
+  if (secret !== process.env.SANITY_PREVIEW_SECRET) {
+    return res.status(401).json({ message: 'Invalid token' })
+  }
+
+  // Validate document exists
+  if (!slug || !type) {
+    return res.status(400).json({ message: 'Missing slug or type' })
+  }
+
+  // Check document exists in Sanity
+  const exists = await previewClient.fetch(
+    `*[_type == $type && slug.current == $slug][0]._id`,
+    { type, slug }
+  )
+
+  if (!exists) {
+    return res.status(404).json({ message: 'Document not found' })
+  }
+
+  // Enable Preview Mode
+  res.setPreviewData({})
+
+  // Redirect to the document's page
+  const redirectUrl = type === 'post' ? `/blog/${slug}` : `/${slug}`
+  res.redirect(redirectUrl)
+}
+```
+
+**2. Disable Preview API Route (`pages/api/exit-preview.ts`):**
+
+```typescript
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.clearPreviewData()
+  res.redirect(req.headers.referer || '/')
+}
+```
+
+**3. Preview Banner Component:**
+
+```typescript
+// components/PreviewBanner.tsx
+export function PreviewBanner() {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-yellow-400 p-2 text-center z-50">
+      <span className="font-bold">Preview Mode</span>
+      {' - '}
+      <a href="/api/exit-preview" className="underline">
+        Exit Preview
+      </a>
+    </div>
+  )
+}
+```
+
+**4. Use in pages:**
+
+```typescript
+export async function getStaticProps({ params, preview = false, previewData }) {
+  const client = getClient(preview)
+  
+  // In preview mode, fetch drafts
+  const perspective = preview ? 'previewDrafts' : 'published'
+  
+  const post = await client.fetch(
+    POST_QUERY,
+    { slug: params.slug },
+    { perspective }
+  )
+
+  return {
+    props: { post, preview },
+    revalidate: preview ? 1 : 60, // Fast revalidation in preview
+  }
+}
+```
+
+### Fetching Draft Content
+
+In Preview Mode, you want to see unpublished changes:
+
+```typescript
+// Fetch with draft perspective
+const post = await previewClient.fetch(
+  QUERY,
+  params,
+  { perspective: 'previewDrafts' }
+)
+```
+
+The `previewDrafts` perspective:
+- Returns draft versions if they exist
+- Falls back to published versions
+- Requires a token with read access
+
+### Real-Time Preview (Optional)
+
+For live updates as editors type, use `@sanity/preview-kit`:
+
+```typescript
+// pages/blog/[slug].tsx
+import { usePreview } from '@/sanity/lib/preview'
+
+export default function PostPage({ post, preview }) {
+  // In preview mode, subscribe to real-time updates
+  const livePost = usePreview(preview, POST_QUERY, { slug: post.slug })
+  const data = livePost || post
+
+  return (
+    <>
+      {preview && <PreviewBanner />}
+      <article>
+        <h1>{data.title}</h1>
+      </article>
+    </>
+  )
+}
+```
+
+**Preview hook setup:**
+
+```typescript
+// src/sanity/lib/preview.ts
+import { definePreview } from '@sanity/preview-kit'
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
+
+export const usePreview = definePreview({ projectId, dataset })
+```
+
+### getServerSideProps (When to Use)
+
+Use `getServerSideProps` only when you need:
+- Request-time data (user session, cookies)
+- Data that changes on every request
+- Personalized content
+
+```typescript
+export async function getServerSideProps({ req, params }) {
+  // Access cookies/headers
+  const userToken = req.cookies.token
+  
+  const data = await client.fetch(QUERY, { 
+    ...params,
+    userId: userToken ? decodeToken(userToken).userId : null 
+  })
+
+  return { props: { data } }
+}
+```
+
+**Avoid `getServerSideProps` for:**
+- Public content (use `getStaticProps` + ISR)
+- SEO-critical pages (SSG is faster)
+
+### Migration to App Router
+
+When ready to migrate:
+
+1. **Move pages incrementally** - Both routers can coexist
+2. **Replace `getStaticProps`** with `sanityFetch` + `defineLive`
+3. **Replace Preview Mode** with Draft Mode
+4. **Replace ISR `revalidate`** with tag-based revalidation
+
+See `data-fetching-app-router.md` for App Router patterns.
+
+Reference: [Next.js Pages Router docs](https://nextjs.org/docs/pages)

--- a/skills/sanity-nextjs-best-practices/rules/images-nextjs.md
+++ b/skills/sanity-nextjs-best-practices/rules/images-nextjs.md
@@ -1,0 +1,326 @@
+---
+title: Images with next/image
+description: Integrate Sanity images with Next.js Image component, urlFor, and LQIP placeholders
+tags: nextjs, images, next-image, urlFor, lqip, blur-placeholder
+---
+
+## Images with next/image
+
+Sanity's image pipeline combined with `next/image` provides optimized, responsive images with blur placeholders.
+
+### Schema: Always Enable Hotspot
+
+```typescript
+import { defineField } from 'sanity'
+
+defineField({
+  name: 'mainImage',
+  title: 'Main Image',
+  type: 'image',
+  options: {
+    hotspot: true, // Allow editors to set focal point
+  },
+  fields: [
+    defineField({
+      name: 'alt',
+      type: 'string',
+      title: 'Alternative Text',
+      validation: (rule) => rule.required().warning('Alt text improves SEO'),
+    }),
+  ],
+})
+```
+
+### URL Builder Setup
+
+**`src/sanity/lib/image.ts`:**
+
+```typescript
+import createImageUrlBuilder from '@sanity/image-url'
+import type { SanityImageSource } from '@sanity/image-url/lib/types/types'
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
+
+const builder = createImageUrlBuilder({ projectId, dataset })
+
+export function urlFor(source: SanityImageSource) {
+  return builder.image(source)
+}
+```
+
+### Querying Images with LQIP
+
+**Critical:** LQIP (Low Quality Image Placeholder) is **not automatic**. You must query it explicitly.
+
+**Minimal query (no blur placeholder):**
+
+```groq
+mainImage {
+  asset->{ _id, url },
+  alt
+}
+```
+
+**Full query (with LQIP and dimensions):**
+
+```groq
+mainImage {
+  asset->{
+    _id,
+    url,
+    metadata {
+      lqip,                          // Base64 blur placeholder
+      dimensions { width, height }   // For aspect ratio
+    }
+  },
+  alt,
+  hotspot,
+  crop
+}
+```
+
+### Reusable Image Fragment
+
+```typescript
+// src/sanity/lib/fragments.ts
+export const imageFragment = /* groq */ `
+  asset->{
+    _id,
+    url,
+    metadata {
+      lqip,
+      dimensions { width, height }
+    }
+  },
+  alt,
+  hotspot,
+  crop
+`
+```
+
+Use in queries:
+
+```typescript
+import { imageFragment } from './fragments'
+
+const POST_QUERY = defineQuery(`
+  *[_type == "post"][0]{
+    title,
+    mainImage { ${imageFragment} }
+  }
+`)
+```
+
+### SanityImage Component
+
+Create a reusable component that handles all the integration:
+
+```typescript
+// src/components/SanityImage.tsx
+import Image from 'next/image'
+import { urlFor } from '@/sanity/lib/image'
+
+type SanityImageValue = {
+  asset?: {
+    _id: string
+    url: string
+    metadata?: {
+      lqip?: string
+      dimensions?: { width: number; height: number }
+    }
+  }
+  alt?: string
+  hotspot?: { x: number; y: number }
+  crop?: { top: number; bottom: number; left: number; right: number }
+}
+
+type SanityImageProps = {
+  value: SanityImageValue
+  width?: number
+  height?: number
+  sizes?: string
+  className?: string
+  priority?: boolean
+  fill?: boolean
+}
+
+export function SanityImage({
+  value,
+  width = 800,
+  height,
+  sizes,
+  className,
+  priority = false,
+  fill = false,
+}: SanityImageProps) {
+  if (!value?.asset) return null
+
+  const dimensions = value.asset.metadata?.dimensions
+  const aspectRatio = dimensions 
+    ? dimensions.width / dimensions.height 
+    : 1.5
+
+  const computedHeight = height || Math.round(width / aspectRatio)
+
+  // Build optimized URL
+  const src = urlFor(value)
+    .width(width)
+    .height(computedHeight)
+    .fit('crop')
+    .url()
+
+  const commonProps = {
+    src,
+    alt: value.alt || '',
+    className,
+    priority,
+    placeholder: value.asset.metadata?.lqip ? 'blur' as const : 'empty' as const,
+    blurDataURL: value.asset.metadata?.lqip,
+  }
+
+  if (fill) {
+    return (
+      <Image
+        {...commonProps}
+        fill
+        sizes={sizes || '100vw'}
+        style={{ objectFit: 'cover' }}
+      />
+    )
+  }
+
+  return (
+    <Image
+      {...commonProps}
+      width={width}
+      height={computedHeight}
+      sizes={sizes}
+    />
+  )
+}
+```
+
+### Usage Examples
+
+**Basic usage:**
+
+```typescript
+<SanityImage value={post.mainImage} width={800} />
+```
+
+**Hero image (full width):**
+
+```typescript
+<div className="relative h-[60vh]">
+  <SanityImage 
+    value={page.heroImage} 
+    fill 
+    priority 
+    sizes="100vw"
+    className="object-cover"
+  />
+</div>
+```
+
+**Responsive card image:**
+
+```typescript
+<SanityImage 
+  value={post.thumbnail} 
+  width={400}
+  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+/>
+```
+
+### Hotspot-Aware Cropping
+
+When using `fill` or specific crops, respect the editor's hotspot:
+
+```typescript
+function HotspotImage({ value, className }) {
+  if (!value?.asset) return null
+
+  const hotspot = value.hotspot || { x: 0.5, y: 0.5 }
+  
+  return (
+    <div className={`relative overflow-hidden ${className}`}>
+      <Image
+        src={urlFor(value).width(1200).url()}
+        alt={value.alt || ''}
+        fill
+        style={{
+          objectFit: 'cover',
+          objectPosition: `${hotspot.x * 100}% ${hotspot.y * 100}%`,
+        }}
+      />
+    </div>
+  )
+}
+```
+
+### Responsive Images with srcSet
+
+For advanced responsive images:
+
+```typescript
+function ResponsiveImage({ value }) {
+  const widths = [400, 800, 1200, 1600]
+  
+  return (
+    <Image
+      src={urlFor(value).width(1200).url()}
+      alt={value.alt || ''}
+      width={1200}
+      height={800}
+      sizes="(max-width: 400px) 400px, (max-width: 800px) 800px, 1200px"
+      // next/image handles srcSet automatically
+    />
+  )
+}
+```
+
+### Performance Tips
+
+| Tip | Why |
+|-----|-----|
+| Always query LQIP | Enables blur placeholder for better UX |
+| Set explicit dimensions | Prevents Cumulative Layout Shift (CLS) |
+| Use `priority` for LCP images | Improves Largest Contentful Paint |
+| Use appropriate `sizes` | Helps browser pick right srcSet |
+| Use Sanity CDN sizing | Don't download 4000px for thumbnails |
+
+### Without LQIP
+
+If you don't query `metadata.lqip`, the blur effect won't work:
+
+```typescript
+// This won't show blur placeholder
+<Image
+  src={urlFor(value).url()}
+  placeholder="blur"
+  blurDataURL={value.asset.metadata?.lqip} // undefined!
+/>
+```
+
+Always include LQIP in your image queries for the best user experience.
+
+### next.config.js Setup
+
+Allow Sanity CDN images:
+
+```javascript
+// next.config.js
+module.exports = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.sanity.io',
+      },
+    ],
+  },
+}
+```
+
+Reference: [Sanity Image URLs](https://www.sanity.io/docs/image-urls)

--- a/skills/sanity-nextjs-best-practices/rules/page-builder-nextjs.md
+++ b/skills/sanity-nextjs-best-practices/rules/page-builder-nextjs.md
@@ -1,0 +1,355 @@
+---
+title: Page Builder Rendering in Next.js
+description: Patterns for rendering page builder blocks with type safety and Visual Editing
+tags: nextjs, page-builder, blocks, typescript, switch-rendering
+---
+
+## Page Builder Rendering in Next.js
+
+Page builders are arrays of block objects that allow content teams to compose flexible page layouts. This guide covers rendering patterns for Next.js.
+
+### Basic Switch Pattern
+
+The most straightforward approach for rendering blocks:
+
+```typescript
+// src/components/PageBuilder.tsx
+import { Hero } from './blocks/Hero'
+import { Features } from './blocks/Features'
+import { FAQ } from './blocks/FAQ'
+import { CTA } from './blocks/CTA'
+
+type Block = {
+  _type: string
+  _key: string
+  [key: string]: any
+}
+
+type PageBuilderProps = {
+  content: Block[]
+  documentId?: string
+}
+
+export function PageBuilder({ content, documentId }: PageBuilderProps) {
+  if (!Array.isArray(content)) return null
+
+  return (
+    <main>
+      {content.map((block) => {
+        switch (block._type) {
+          case 'hero':
+            return <Hero key={block._key} documentId={documentId} {...block} />
+          case 'features':
+            return <Features key={block._key} documentId={documentId} {...block} />
+          case 'faq':
+            return <FAQ key={block._key} documentId={documentId} {...block} />
+          case 'cta':
+            return <CTA key={block._key} documentId={documentId} {...block} />
+          default:
+            console.warn(`Unknown block type: ${block._type}`)
+            return (
+              <div key={block._key} className="p-4 bg-yellow-100 border border-yellow-400">
+                Unknown block type: {block._type}
+              </div>
+            )
+        }
+      })}
+    </main>
+  )
+}
+```
+
+### Always Use _key for React Keys
+
+**Critical:** Always use Sanity's `_key` for React keys, never array index.
+
+```typescript
+// Bad: Breaks Visual Editing and causes hydration issues
+{content.map((block, index) => (
+  <Component key={index} {...block} />
+))}
+
+// Good: Stable keys from Sanity
+{content.map((block) => (
+  <Component key={block._key} {...block} />
+))}
+```
+
+### TypeScript Typing with Extract
+
+Use `Extract` to create typed props for each block component:
+
+```typescript
+// src/sanity/lib/types.ts
+import type { PAGE_QUERYResult } from '@/sanity/types'
+
+// Non-nullable content array
+type ContentBlocks = NonNullable<NonNullable<PAGE_QUERYResult>['content']>
+
+// Single block (union of all types)
+type ContentBlock = ContentBlocks[number]
+
+// Extract specific block types
+export type HeroBlock = Extract<ContentBlock, { _type: 'hero' }>
+export type FeaturesBlock = Extract<ContentBlock, { _type: 'features' }>
+export type FAQBlock = Extract<ContentBlock, { _type: 'faq' }>
+export type CTABlock = Extract<ContentBlock, { _type: 'cta' }>
+```
+
+**Use in components:**
+
+```typescript
+// src/components/blocks/Hero.tsx
+import type { HeroBlock } from '@/sanity/lib/types'
+
+type HeroProps = HeroBlock & {
+  documentId?: string
+}
+
+export function Hero({ title, subtitle, image, cta, documentId }: HeroProps) {
+  return (
+    <section className="py-20 text-center">
+      <h1 className="text-5xl font-bold">{title}</h1>
+      {subtitle && <p className="text-xl mt-4 text-gray-600">{subtitle}</p>}
+      {/* ... */}
+    </section>
+  )
+}
+```
+
+### Block Registry Pattern
+
+For larger projects, use a registry object instead of switch:
+
+```typescript
+// src/components/blocks/index.ts
+import { Hero } from './Hero'
+import { Features } from './Features'
+import { FAQ } from './FAQ'
+import { CTA } from './CTA'
+import type { ComponentType } from 'react'
+
+export const blockComponents: Record<string, ComponentType<any>> = {
+  hero: Hero,
+  features: Features,
+  faq: FAQ,
+  cta: CTA,
+}
+```
+
+```typescript
+// src/components/PageBuilder.tsx
+import { blockComponents } from './blocks'
+
+export function PageBuilder({ content, documentId }: PageBuilderProps) {
+  return (
+    <main>
+      {content.map((block) => {
+        const Component = blockComponents[block._type]
+        
+        if (!Component) {
+          return <UnknownBlock key={block._key} type={block._type} />
+        }
+        
+        return <Component key={block._key} documentId={documentId} {...block} />
+      })}
+    </main>
+  )
+}
+```
+
+### Cleaning Values for Logic
+
+Use `stegaClean` when block fields control rendering logic:
+
+```typescript
+import { stegaClean } from 'next-sanity'
+
+type SplitImageProps = {
+  orientation?: string
+  title: string
+  image: any
+}
+
+export function SplitImage({ orientation, title, image }: SplitImageProps) {
+  const cleanOrientation = stegaClean(orientation) || 'imageLeft'
+  
+  return (
+    <section 
+      className="flex" 
+      data-orientation={cleanOrientation}
+    >
+      {cleanOrientation === 'imageLeft' ? (
+        <>
+          <ImageSection image={image} />
+          <TextSection title={title} />
+        </>
+      ) : (
+        <>
+          <TextSection title={title} />
+          <ImageSection image={image} />
+        </>
+      )}
+    </section>
+  )
+}
+```
+
+### Alignment Utility
+
+Common pattern for alignment fields:
+
+```typescript
+// src/lib/utils.ts
+import { stegaClean } from 'next-sanity'
+
+type Alignment = 'left' | 'center' | 'right'
+
+export function getAlignmentClasses(align?: string): string {
+  const clean = stegaClean(align) as Alignment | undefined
+  
+  switch (clean) {
+    case 'left':
+      return 'text-left'
+    case 'right':
+      return 'text-right ml-auto'
+    case 'center':
+    default:
+      return 'text-center mx-auto'
+  }
+}
+```
+
+### Querying Page Builder Content
+
+Expand nested content and references:
+
+```typescript
+const PAGE_QUERY = defineQuery(`
+  *[_type == "page" && slug.current == $slug][0]{
+    _id,
+    title,
+    content[]{
+      ...,
+      _type == "hero" => {
+        title,
+        subtitle,
+        image { ${imageFragment} },
+        cta { label, url }
+      },
+      _type == "features" => {
+        title,
+        features[]{
+          _key,
+          title,
+          description,
+          icon
+        }
+      },
+      _type == "faq" => {
+        title,
+        items[]->{ _id, question, answer }
+      }
+    }
+  }
+`)
+```
+
+### Page Component
+
+```typescript
+// src/app/[slug]/page.tsx
+import { notFound } from 'next/navigation'
+import { sanityFetch } from '@/sanity/lib/live'
+import { PageBuilder } from '@/components/PageBuilder'
+
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  
+  const { data } = await sanityFetch({
+    query: PAGE_QUERY,
+    params: { slug },
+  })
+
+  if (!data) notFound()
+
+  return (
+    <PageBuilder 
+      content={data.content} 
+      documentId={data._id}
+    />
+  )
+}
+```
+
+### Semantic Heading Levels
+
+Don't store heading levels in Sanity. Determine them dynamically for accessibility:
+
+```typescript
+// Bad: Heading level in CMS
+{ name: 'headingLevel', type: 'string', options: { list: ['h1', 'h2', 'h3'] } }
+
+// Good: Pass level as prop based on context
+type SectionProps = {
+  title: string
+  headingLevel?: 'h1' | 'h2' | 'h3'
+}
+
+export function Section({ title, headingLevel = 'h2' }: SectionProps) {
+  const Tag = headingLevel
+  return <Tag className="text-3xl font-bold">{title}</Tag>
+}
+```
+
+In PageBuilder:
+
+```typescript
+{content.map((block, index) => {
+  // First block gets h1, others get h2
+  const headingLevel = index === 0 ? 'h1' : 'h2'
+  
+  switch (block._type) {
+    case 'hero':
+      return <Hero key={block._key} headingLevel={headingLevel} {...block} />
+    // ...
+  }
+})}
+```
+
+### Error Boundaries
+
+Wrap page builder in error boundary for resilience:
+
+```typescript
+'use client'
+import { ErrorBoundary } from 'react-error-boundary'
+
+function BlockErrorFallback({ error, resetErrorBoundary }) {
+  return (
+    <div className="p-4 bg-red-50 border border-red-200 rounded">
+      <p className="text-red-700">Failed to render block</p>
+      <button onClick={resetErrorBoundary} className="text-sm underline">
+        Try again
+      </button>
+    </div>
+  )
+}
+
+export function PageBuilder({ content, documentId }) {
+  return (
+    <main>
+      {content.map((block) => (
+        <ErrorBoundary 
+          key={block._key} 
+          FallbackComponent={BlockErrorFallback}
+        >
+          <BlockRenderer block={block} documentId={documentId} />
+        </ErrorBoundary>
+      ))}
+    </main>
+  )
+}
+```
+
+Reference: [Page Builder patterns](https://www.sanity.io/guides/how-to-build-a-page-builder-in-sanity-studio)

--- a/skills/sanity-nextjs-best-practices/rules/seo-metadata.md
+++ b/skills/sanity-nextjs-best-practices/rules/seo-metadata.md
@@ -1,0 +1,322 @@
+---
+title: SEO Metadata with generateMetadata
+description: Generate type-safe metadata from Sanity with stega disabled
+tags: nextjs, seo, metadata, generateMetadata, open-graph
+---
+
+## SEO Metadata with generateMetadata
+
+Next.js App Router's `generateMetadata` function generates page metadata from Sanity content. **Critical:** Always disable stega for metadata queries.
+
+### Basic Pattern
+
+```typescript
+// src/app/blog/[slug]/page.tsx
+import { Metadata } from 'next'
+import { sanityFetch } from '@/sanity/lib/live'
+import { urlFor } from '@/sanity/lib/image'
+
+const SEO_QUERY = defineQuery(`
+  *[_type == "post" && slug.current == $slug][0]{
+    title,
+    excerpt,
+    "slug": slug.current,
+    mainImage,
+    seo {
+      metaTitle,
+      metaDescription,
+      ogImage
+    }
+  }
+`)
+
+export async function generateMetadata({ 
+  params 
+}: { 
+  params: Promise<{ slug: string }> 
+}): Promise<Metadata> {
+  const { slug } = await params
+  
+  const { data } = await sanityFetch({
+    query: SEO_QUERY,
+    params: { slug },
+    stega: false, // CRITICAL: No stega in metadata
+  })
+
+  if (!data) {
+    return { title: 'Not Found' }
+  }
+
+  const title = data.seo?.metaTitle || data.title
+  const description = data.seo?.metaDescription || data.excerpt
+  const image = data.seo?.ogImage || data.mainImage
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'article',
+      url: `/blog/${slug}`,
+      images: image ? [{
+        url: urlFor(image).width(1200).height(630).url(),
+        width: 1200,
+        height: 630,
+        alt: title,
+      }] : [],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: image ? [urlFor(image).width(1200).height(630).url()] : [],
+    },
+  }
+}
+```
+
+### Why stega: false is Critical
+
+Stega characters in metadata will:
+- Appear in browser tabs as garbled text
+- Show in Google search results
+- Break social media previews
+- Corrupt structured data
+
+```typescript
+// BAD: Stega enabled (default)
+const { data } = await sanityFetch({ query: SEO_QUERY })
+// title = "My Post Title" + invisible characters
+
+// GOOD: Stega disabled
+const { data } = await sanityFetch({ query: SEO_QUERY, stega: false })
+// title = "My Post Title"
+```
+
+### SEO Schema Pattern
+
+Define a reusable SEO object in your schema:
+
+```typescript
+// schemaTypes/objects/seo.ts
+import { defineType, defineField } from 'sanity'
+
+export const seoType = defineType({
+  name: 'seo',
+  title: 'SEO',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'metaTitle',
+      title: 'Meta Title',
+      type: 'string',
+      description: 'Override the default title (50-60 characters recommended)',
+      validation: (rule) => rule.max(60).warning('Title should be under 60 characters'),
+    }),
+    defineField({
+      name: 'metaDescription',
+      title: 'Meta Description',
+      type: 'text',
+      rows: 3,
+      description: 'Override the default description (150-160 characters recommended)',
+      validation: (rule) => rule.max(160).warning('Description should be under 160 characters'),
+    }),
+    defineField({
+      name: 'ogImage',
+      title: 'Social Share Image',
+      type: 'image',
+      description: 'Image for social media sharing (1200x630 recommended)',
+    }),
+    defineField({
+      name: 'noIndex',
+      title: 'Hide from Search Engines',
+      type: 'boolean',
+      description: 'Prevent this page from appearing in search results',
+      initialValue: false,
+    }),
+  ],
+})
+```
+
+### Handling noIndex
+
+```typescript
+export async function generateMetadata({ params }): Promise<Metadata> {
+  const { data } = await sanityFetch({
+    query: SEO_QUERY,
+    params,
+    stega: false,
+  })
+
+  return {
+    title: data.seo?.metaTitle || data.title,
+    description: data.seo?.metaDescription,
+    robots: data.seo?.noIndex 
+      ? { index: false, follow: false }
+      : { index: true, follow: true },
+  }
+}
+```
+
+### Canonical URLs
+
+Prevent duplicate content issues:
+
+```typescript
+export async function generateMetadata({ params }): Promise<Metadata> {
+  const { slug } = await params
+  
+  return {
+    // ... other metadata
+    alternates: {
+      canonical: `https://example.com/blog/${slug}`,
+    },
+  }
+}
+```
+
+### Default Metadata in Layout
+
+Set site-wide defaults in your root layout:
+
+```typescript
+// src/app/layout.tsx
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://example.com'),
+  title: {
+    default: 'My Site',
+    template: '%s | My Site', // "Page Title | My Site"
+  },
+  description: 'Default site description',
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    siteName: 'My Site',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    site: '@mysite',
+  },
+}
+```
+
+### Fetching Site Settings
+
+For global SEO settings from Sanity:
+
+```typescript
+// src/app/layout.tsx
+import { sanityFetch } from '@/sanity/lib/live'
+
+const SETTINGS_QUERY = defineQuery(`
+  *[_type == "settings"][0]{
+    siteName,
+    siteDescription,
+    defaultOgImage,
+    twitterHandle
+  }
+`)
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { data: settings } = await sanityFetch({
+    query: SETTINGS_QUERY,
+    stega: false,
+  })
+
+  return {
+    metadataBase: new URL('https://example.com'),
+    title: {
+      default: settings?.siteName || 'My Site',
+      template: `%s | ${settings?.siteName || 'My Site'}`,
+    },
+    description: settings?.siteDescription,
+    openGraph: {
+      images: settings?.defaultOgImage 
+        ? [urlFor(settings.defaultOgImage).width(1200).height(630).url()]
+        : [],
+    },
+    twitter: {
+      site: settings?.twitterHandle,
+    },
+  }
+}
+```
+
+### Structured Data (JSON-LD)
+
+Add structured data for rich search results:
+
+```typescript
+// src/app/blog/[slug]/page.tsx
+import { sanityFetch } from '@/sanity/lib/live'
+
+export default async function BlogPost({ params }) {
+  const { data } = await sanityFetch({
+    query: POST_QUERY,
+    params: await params,
+  })
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: data.title,
+    description: data.excerpt,
+    image: data.mainImage ? urlFor(data.mainImage).width(1200).url() : undefined,
+    datePublished: data.publishedAt,
+    author: {
+      '@type': 'Person',
+      name: data.author?.name,
+    },
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <article>{/* ... */}</article>
+    </>
+  )
+}
+```
+
+### Pages Router Pattern
+
+For Pages Router, use `next/head`:
+
+```typescript
+// pages/blog/[slug].tsx
+import Head from 'next/head'
+import { urlFor } from '@/sanity/lib/image'
+
+export default function BlogPost({ post }) {
+  const title = post.seo?.metaTitle || post.title
+  const description = post.seo?.metaDescription || post.excerpt
+  const image = post.seo?.ogImage || post.mainImage
+
+  return (
+    <>
+      <Head>
+        <title>{title} | My Site</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        {image && (
+          <meta 
+            property="og:image" 
+            content={urlFor(image).width(1200).height(630).url()} 
+          />
+        )}
+        <link rel="canonical" href={`https://example.com/blog/${post.slug}`} />
+      </Head>
+      <article>{/* ... */}</article>
+    </>
+  )
+}
+```
+
+Reference: [Next.js Metadata](https://nextjs.org/docs/app/building-your-application/optimizing/metadata)

--- a/skills/sanity-nextjs-best-practices/rules/seo-sitemap-og.md
+++ b/skills/sanity-nextjs-best-practices/rules/seo-sitemap-og.md
@@ -1,0 +1,404 @@
+---
+title: Sitemaps and OG Images
+description: Generate dynamic sitemaps and Open Graph images from Sanity content
+tags: nextjs, seo, sitemap, og-image, robots
+---
+
+## Sitemaps and OG Images
+
+Dynamic sitemaps and Open Graph images improve SEO and social sharing. Generate both from Sanity content.
+
+### Dynamic Sitemap
+
+**`src/app/sitemap.ts`:**
+
+```typescript
+import { MetadataRoute } from 'next'
+import { client } from '@/sanity/lib/client'
+
+const SITEMAP_QUERY = /* groq */ `
+  *[_type in ["page", "post"] && defined(slug.current) && seo.noIndex != true]{
+    _type,
+    "slug": slug.current,
+    _updatedAt
+  }
+`
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = 'https://example.com'
+  
+  // Fetch all public pages from Sanity
+  const documents = await client.fetch(SITEMAP_QUERY, {}, { 
+    cache: 'no-store' // Always fresh for sitemap
+  })
+
+  const pages = documents.map((doc: any) => {
+    let url: string
+    
+    switch (doc._type) {
+      case 'page':
+        url = doc.slug === 'home' ? baseUrl : `${baseUrl}/${doc.slug}`
+        break
+      case 'post':
+        url = `${baseUrl}/blog/${doc.slug}`
+        break
+      default:
+        url = `${baseUrl}/${doc.slug}`
+    }
+
+    return {
+      url,
+      lastModified: new Date(doc._updatedAt),
+      changeFrequency: 'weekly' as const,
+      priority: doc._type === 'page' ? 0.8 : 0.6,
+    }
+  })
+
+  // Add static pages
+  const staticPages = [
+    { url: baseUrl, lastModified: new Date(), priority: 1 },
+    { url: `${baseUrl}/blog`, lastModified: new Date(), priority: 0.8 },
+    { url: `${baseUrl}/contact`, lastModified: new Date(), priority: 0.5 },
+  ]
+
+  return [...staticPages, ...pages]
+}
+```
+
+### Multiple Sitemaps (Large Sites)
+
+For sites with many pages, split into multiple sitemaps:
+
+```typescript
+// src/app/sitemap.ts
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://example.com',
+      lastModified: new Date(),
+    },
+  ]
+}
+
+export async function generateSitemaps() {
+  // Return array of sitemap IDs
+  const totalPosts = await client.fetch(`count(*[_type == "post"])`)
+  const postsPerSitemap = 1000
+  const sitemapCount = Math.ceil(totalPosts / postsPerSitemap)
+  
+  return Array.from({ length: sitemapCount }, (_, i) => ({ id: i }))
+}
+```
+
+```typescript
+// src/app/blog/sitemap/[id]/route.ts
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = parseInt(params.id)
+  const start = id * 1000
+  const end = start + 1000
+
+  const posts = await client.fetch(
+    `*[_type == "post"] | order(_createdAt) [$start...$end]{ slug, _updatedAt }`,
+    { start, end }
+  )
+
+  // Generate sitemap XML...
+}
+```
+
+### robots.txt
+
+**`src/app/robots.ts`:**
+
+```typescript
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = 'https://example.com'
+  
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/studio/', '/admin/'],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}
+```
+
+### Dynamic OG Images
+
+Generate Open Graph images on-the-fly using Next.js `ImageResponse`:
+
+**`src/app/blog/[slug]/opengraph-image.tsx`:**
+
+```typescript
+import { ImageResponse } from 'next/og'
+import { client } from '@/sanity/lib/client'
+
+export const runtime = 'edge'
+export const alt = 'Blog post image'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+const OG_QUERY = /* groq */ `
+  *[_type == "post" && slug.current == $slug][0]{
+    title,
+    author->{ name }
+  }
+`
+
+export default async function OGImage({ 
+  params 
+}: { 
+  params: { slug: string } 
+}) {
+  const post = await client.fetch(OG_QUERY, { slug: params.slug })
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#1a1a1a',
+          padding: 60,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 60,
+            fontWeight: 700,
+            color: 'white',
+            textAlign: 'center',
+            lineHeight: 1.2,
+            maxWidth: 900,
+          }}
+        >
+          {post?.title || 'Blog Post'}
+        </div>
+        {post?.author?.name && (
+          <div
+            style={{
+              marginTop: 30,
+              fontSize: 30,
+              color: '#888',
+            }}
+          >
+            By {post.author.name}
+          </div>
+        )}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 40,
+            fontSize: 24,
+            color: '#666',
+          }}
+        >
+          example.com
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}
+```
+
+### OG Image with Custom Fonts
+
+```typescript
+import { ImageResponse } from 'next/og'
+
+// Load font
+const interBold = fetch(
+  new URL('./Inter-Bold.ttf', import.meta.url)
+).then((res) => res.arrayBuffer())
+
+export default async function OGImage({ params }) {
+  const fontData = await interBold
+  
+  return new ImageResponse(
+    (
+      <div style={{ fontFamily: 'Inter' }}>
+        {/* ... */}
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: 'Inter',
+          data: fontData,
+          style: 'normal',
+          weight: 700,
+        },
+      ],
+    }
+  )
+}
+```
+
+### OG Image with Sanity Image
+
+Fetch and display a Sanity image in your OG image:
+
+```typescript
+import { ImageResponse } from 'next/og'
+import { urlFor } from '@/sanity/lib/image'
+
+export default async function OGImage({ params }) {
+  const post = await client.fetch(OG_QUERY, { slug: params.slug })
+  
+  const imageUrl = post?.mainImage 
+    ? urlFor(post.mainImage).width(1200).height(630).url()
+    : null
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          position: 'relative',
+        }}
+      >
+        {imageUrl && (
+          <img
+            src={imageUrl}
+            style={{
+              position: 'absolute',
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+            }}
+          />
+        )}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            padding: 40,
+            background: 'linear-gradient(transparent, rgba(0,0,0,0.8))',
+            color: 'white',
+          }}
+        >
+          <div style={{ fontSize: 48, fontWeight: 700 }}>
+            {post?.title}
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}
+```
+
+### Reusable OG Image Template
+
+Create a shared template for consistent branding:
+
+```typescript
+// src/lib/og-template.tsx
+export function OGTemplate({ 
+  title, 
+  subtitle,
+  imageUrl,
+}: { 
+  title: string
+  subtitle?: string
+  imageUrl?: string
+}) {
+  return (
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: '#0f172a',
+        backgroundImage: imageUrl 
+          ? `url(${imageUrl})`
+          : 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        backgroundSize: 'cover',
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'flex-end',
+          padding: 60,
+          background: 'linear-gradient(transparent 40%, rgba(0,0,0,0.9))',
+        }}
+      >
+        <div style={{ color: 'white', fontSize: 56, fontWeight: 700, lineHeight: 1.2 }}>
+          {title}
+        </div>
+        {subtitle && (
+          <div style={{ color: '#94a3b8', fontSize: 28, marginTop: 16 }}>
+            {subtitle}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+### Pages Router Sitemap
+
+For Pages Router, use `getServerSideProps`:
+
+```typescript
+// pages/sitemap.xml.tsx
+import { GetServerSideProps } from 'next'
+import { client } from '@/sanity/lib/client'
+
+function Sitemap() {
+  return null
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  const baseUrl = 'https://example.com'
+  const documents = await client.fetch(SITEMAP_QUERY)
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      ${documents
+        .map((doc: any) => `
+          <url>
+            <loc>${baseUrl}/${doc.slug}</loc>
+            <lastmod>${doc._updatedAt}</lastmod>
+          </url>
+        `)
+        .join('')}
+    </urlset>`
+
+  res.setHeader('Content-Type', 'text/xml')
+  res.write(sitemap)
+  res.end()
+
+  return { props: {} }
+}
+
+export default Sitemap
+```
+
+Reference: [Next.js Metadata Files](https://nextjs.org/docs/app/api-reference/file-conventions/metadata)

--- a/skills/sanity-nextjs-best-practices/rules/typegen-workflow.md
+++ b/skills/sanity-nextjs-best-practices/rules/typegen-workflow.md
@@ -1,0 +1,276 @@
+---
+title: TypeGen Workflow
+description: Generate TypeScript types from Sanity schema and GROQ queries
+tags: nextjs, typescript, typegen, defineQuery, type-safety
+---
+
+## TypeGen Workflow
+
+Sanity TypeGen generates TypeScript types from your schema and GROQ queries. This ensures type safety across your entire application.
+
+### The Workflow
+
+1. **Extract**: Convert schema (TS/JS) to static JSON
+2. **Generate**: Scan codebase for `defineQuery` calls, generate types
+
+Run this cycle whenever schema or queries change.
+
+### Setup
+
+**1. Create config file (`sanity-typegen.json`):**
+
+```json
+{
+  "path": "./src/**/*.{ts,tsx,js,jsx}",
+  "schema": "./schema.json",
+  "generates": "./src/sanity/types.ts"
+}
+```
+
+**2. Add npm scripts (`package.json`):**
+
+```json
+{
+  "scripts": {
+    "typegen": "sanity schema extract --path=./schema.json && sanity typegen generate",
+    "predev": "npm run typegen",
+    "prebuild": "npm run typegen"
+  }
+}
+```
+
+**3. Run TypeGen:**
+
+```bash
+npm run typegen
+```
+
+### Always Use defineQuery
+
+**Wrap ALL GROQ queries in `defineQuery`** for TypeGen support.
+
+**Incorrect (no types):**
+
+```typescript
+// No TypeGen support, result is `any`
+const query = `*[_type == "post"]{ title, slug }`
+const posts = await client.fetch(query)
+// posts: any
+```
+
+**Correct (with defineQuery):**
+
+```typescript
+import { defineQuery } from 'next-sanity'
+
+// TypeGen generates POST_QUERYResult type automatically
+const POST_QUERY = defineQuery(`*[_type == "post"]{ title, slug }`)
+
+// After running `npm run typegen`:
+import type { POST_QUERYResult } from '@/sanity/types'
+
+const { data } = await sanityFetch({ query: POST_QUERY })
+// data is fully typed!
+```
+
+### Syntax Highlighting
+
+For VS Code syntax highlighting with `defineQuery`:
+
+```typescript
+// Option A: groq tagged template (provides highlighting)
+import groq from 'groq'
+const QUERY = defineQuery(groq`*[_type == "post"]`)
+
+// Option B: Comment prefix
+const QUERY = defineQuery(/* groq */ `*[_type == "post"]`)
+
+// Option C: Just defineQuery (TypeGen works, no highlighting)
+const QUERY = defineQuery(`*[_type == "post"]`)
+```
+
+### Using Generated Types
+
+**Never manually type query results.** Infer from the query:
+
+```typescript
+import { defineQuery } from 'next-sanity'
+import type { POST_QUERYResult } from '@/sanity/types'
+
+const POST_QUERY = defineQuery(`
+  *[_type == "post" && slug.current == $slug][0]{
+    _id,
+    title,
+    body,
+    author->{ name, image }
+  }
+`)
+
+// In components
+type PostProps = {
+  data: NonNullable<POST_QUERYResult>
+}
+
+export function Post({ data }: PostProps) {
+  return (
+    <article>
+      <h1>{data.title}</h1>
+      <p>By {data.author?.name}</p>
+    </article>
+  )
+}
+```
+
+### Query Fragments
+
+Use string interpolation to reuse query logic:
+
+```typescript
+// src/sanity/lib/fragments.ts
+export const imageFragment = /* groq */ `
+  asset->{
+    _id,
+    url,
+    metadata { lqip, dimensions }
+  },
+  alt,
+  hotspot,
+  crop
+`
+
+export const authorFragment = /* groq */ `
+  name,
+  "slug": slug.current,
+  image { ${imageFragment} }
+`
+```
+
+```typescript
+// src/sanity/lib/queries.ts
+import { defineQuery } from 'next-sanity'
+import { imageFragment, authorFragment } from './fragments'
+
+export const POST_QUERY = defineQuery(`
+  *[_type == "post" && slug.current == $slug][0]{
+    _id,
+    title,
+    mainImage { ${imageFragment} },
+    author->{ ${authorFragment} },
+    body
+  }
+`)
+```
+
+### Monorepo Configuration
+
+For monorepos with separate studio and frontend:
+
+**`apps/web/sanity-typegen.json`:**
+
+```json
+{
+  "path": "./src/**/*.{ts,tsx}",
+  "schema": "../studio/schema.json",
+  "generates": "./src/sanity/types.ts"
+}
+```
+
+**Extract schema from studio:**
+
+```bash
+cd apps/studio && npx sanity schema extract --path=./schema.json
+```
+
+### Typing Page Builder Blocks
+
+Use `Extract` to type individual blocks from query results:
+
+```typescript
+import type { PAGE_QUERYResult } from '@/sanity/types'
+
+// Extract a specific block type
+type HeroBlock = Extract<
+  NonNullable<NonNullable<PAGE_QUERYResult>['content']>[number],
+  { _type: 'hero' }
+>
+
+// Now HeroBlock has: title, subtitle, image, etc.
+export function Hero(props: HeroBlock) {
+  return <h1>{props.title}</h1>
+}
+```
+
+### Git Strategy
+
+**Option A: Commit generated types (recommended for most teams)**
+
+```gitignore
+# Don't ignore - commit types
+# sanity.types.ts
+```
+
+Pros:
+- Types available immediately after `git pull`
+- CI doesn't need to run typegen
+
+Cons:
+- Can cause merge conflicts
+
+**Option B: Generate in CI (larger teams)**
+
+```gitignore
+# Sanity TypeGen (generated)
+sanity.types.ts
+schema.json
+```
+
+CI config:
+
+```yaml
+- run: npm run typegen
+- run: npm run build
+```
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Types not updating | Run `npm run typegen` after changes |
+| Query not found | Ensure query uses `defineQuery()` |
+| Schema not found | Run `sanity schema extract` first |
+| TS errors after schema change | Restart TS server in VS Code |
+| Monorepo path issues | Check `schema` path in config |
+
+### Development Workflow
+
+1. Modify schema (`schemaTypes/...`)
+2. Modify queries (`queries.ts`)
+3. Run `npm run typegen`
+4. If VS Code shows stale types, restart TS server (Cmd+Shift+P > "Restart TS Server")
+
+### Type Helpers
+
+Create utility types for common patterns:
+
+```typescript
+// src/sanity/lib/types.ts
+import type { 
+  PAGE_QUERYResult,
+  POST_QUERYResult 
+} from '@/sanity/types'
+
+// Non-nullable page data
+export type PageData = NonNullable<PAGE_QUERYResult>
+
+// Content blocks array
+export type ContentBlocks = NonNullable<PageData['content']>
+
+// Single block union type
+export type ContentBlock = ContentBlocks[number]
+
+// Extract specific block
+export type HeroBlock = Extract<ContentBlock, { _type: 'hero' }>
+export type FeaturesBlock = Extract<ContentBlock, { _type: 'features' }>
+```
+
+Reference: [Sanity TypeGen](https://www.sanity.io/docs/sanity-typegen)

--- a/skills/sanity-nextjs-best-practices/rules/visual-editing-presentation-queries.md
+++ b/skills/sanity-nextjs-best-practices/rules/visual-editing-presentation-queries.md
@@ -1,0 +1,285 @@
+---
+title: Presentation Queries for Faster Editing
+description: Use usePresentationQuery to fetch only the block being edited for instant updates
+tags: nextjs, visual-editing, presentation-queries, usePresentationQuery, performance
+---
+
+## Presentation Queries for Faster Editing
+
+By default, editing a field in the Presentation Tool re-fetches the entire page query and re-renders all components. For pages with many blocks, this feels sluggish.
+
+**Presentation queries** solve this by fetching only the specific block being edited.
+
+### The Problem
+
+Without optimization:
+1. Editor changes a hero title
+2. Entire page query re-runs
+3. All components re-render (hero, features, FAQs, footer...)
+4. Slow, janky experience
+
+With presentation queries:
+1. Editor changes a hero title
+2. Only hero query re-runs
+3. Only hero component re-renders
+4. Fast, responsive experience
+
+### Basic Pattern
+
+**1. Create a block-specific query:**
+
+```typescript
+// src/sanity/lib/queries.ts
+import { defineQuery } from 'next-sanity'
+
+export const HERO_PRESENTATION_QUERY = defineQuery(`
+  *[_id == $documentId][0]{
+    _id,
+    _type,
+    "heroBlock": pageBuilder[_key == $blockKey && _type == "hero"][0]{
+      title,
+      subtitle,
+      image,
+      cta
+    }
+  }
+`)
+```
+
+**2. Use `usePresentationQuery` in your component:**
+
+```typescript
+// src/components/Hero.tsx
+'use client'
+import { usePresentationQuery } from 'next-sanity/hooks'
+import { HERO_PRESENTATION_QUERY } from '@/sanity/lib/queries'
+
+type HeroProps = {
+  _key: string
+  documentId: string
+  title: string
+  subtitle?: string
+  image?: any
+  cta?: { label: string; url: string }
+}
+
+export function Hero({ _key, documentId, ...initialProps }: HeroProps) {
+  // Fetch block-specific data for faster updates
+  const { data } = usePresentationQuery({
+    query: HERO_PRESENTATION_QUERY,
+    params: { documentId, blockKey: _key },
+  })
+
+  // Use presentation data if available, fallback to initial server props
+  const block = data?.heroBlock || initialProps
+
+  return (
+    <section className="py-20">
+      <h1 className="text-5xl font-bold">{block.title}</h1>
+      {block.subtitle && <p className="text-xl mt-4">{block.subtitle}</p>}
+      {block.cta && (
+        <a href={block.cta.url} className="btn mt-8">
+          {block.cta.label}
+        </a>
+      )}
+    </section>
+  )
+}
+```
+
+### Passing Document Context
+
+Your page builder component must pass `documentId` to each block:
+
+```typescript
+// src/components/PageBuilder.tsx
+import { Hero } from './Hero'
+import { Features } from './Features'
+import { FAQ } from './FAQ'
+
+type Block = { _type: string; _key: string; [key: string]: any }
+
+type PageBuilderProps = {
+  content: Block[]
+  documentId: string
+}
+
+export function PageBuilder({ content, documentId }: PageBuilderProps) {
+  if (!Array.isArray(content)) return null
+
+  return (
+    <main>
+      {content.map((block) => {
+        // Pass documentId to each block
+        const props = { ...block, documentId }
+
+        switch (block._type) {
+          case 'hero':
+            return <Hero key={block._key} {...props} />
+          case 'features':
+            return <Features key={block._key} {...props} />
+          case 'faq':
+            return <FAQ key={block._key} {...props} />
+          default:
+            return (
+              <div key={block._key} className="p-4 bg-yellow-100">
+                Unknown block: {block._type}
+              </div>
+            )
+        }
+      })}
+    </main>
+  )
+}
+```
+
+**In your page:**
+
+```typescript
+// src/app/[slug]/page.tsx
+import { sanityFetch } from '@/sanity/lib/live'
+import { PageBuilder } from '@/components/PageBuilder'
+import { defineQuery } from 'next-sanity'
+
+const PAGE_QUERY = defineQuery(`
+  *[_type == "page" && slug.current == $slug][0]{
+    _id,
+    title,
+    "content": pageBuilder[]{
+      ...,
+      _type == "hero" => { title, subtitle, image, cta },
+      _type == "features" => { title, features[] },
+      _type == "faq" => { title, items[]-> }
+    }
+  }
+`)
+
+export default async function Page({ params }) {
+  const { data } = await sanityFetch({
+    query: PAGE_QUERY,
+    params: await params,
+  })
+
+  return (
+    <PageBuilder 
+      content={data.content} 
+      documentId={data._id}  // Pass the document ID
+    />
+  )
+}
+```
+
+### Presentation Query for Portable Text Blocks
+
+The same pattern works for custom blocks inside Portable Text:
+
+```typescript
+// Query for a custom image block in the body
+export const PTE_IMAGE_PRESENTATION_QUERY = defineQuery(`
+  *[_id == $documentId][0]{
+    "pteImageBlock": body[_key == $blockKey && _type == "pteImage"][0]{
+      _key,
+      image,
+      caption,
+      alt
+    }
+  }
+`)
+```
+
+**Component:**
+
+```typescript
+'use client'
+import { usePresentationQuery } from 'next-sanity/hooks'
+import { PTE_IMAGE_PRESENTATION_QUERY } from '@/sanity/lib/queries'
+
+export function PteImage({ value, documentId }: { value: any; documentId?: string }) {
+  const { data } = usePresentationQuery({
+    query: PTE_IMAGE_PRESENTATION_QUERY,
+    params: { documentId, blockKey: value._key },
+  })
+
+  const block = data?.pteImageBlock || value
+
+  return (
+    <figure className="my-8">
+      <SanityImage value={block.image} alt={block.alt} />
+      {block.caption && (
+        <figcaption className="text-sm text-gray-600 mt-2">
+          {block.caption}
+        </figcaption>
+      )}
+    </figure>
+  )
+}
+```
+
+### When to Use Presentation Queries
+
+| Scenario | Use Presentation Query? |
+|----------|------------------------|
+| Page with 5+ blocks | Yes |
+| Complex nested data | Yes |
+| Simple blog post | Optional |
+| Static pages (no editing) | No |
+
+### Performance Considerations
+
+- Presentation queries only run in the Presentation Tool
+- Outside the tool, components use initial server props
+- The `usePresentationQuery` hook returns `undefined` outside presentation mode
+- Always provide fallback to initial props: `data?.block || initialProps`
+
+### Query Structure Tips
+
+**Include all fields the component needs:**
+
+```typescript
+// Good: Complete block data
+"heroBlock": pageBuilder[_key == $blockKey][0]{
+  title,
+  subtitle,
+  image { asset->, alt, hotspot, crop },
+  cta { label, url, style }
+}
+
+// Bad: Missing fields
+"heroBlock": pageBuilder[_key == $blockKey][0]{
+  title
+  // Missing subtitle, image, cta!
+}
+```
+
+**Match your page query projection:**
+
+The presentation query should return the same shape as your page query for that block, so the component works identically with both data sources.
+
+### Debugging
+
+Check if presentation query is active:
+
+```typescript
+'use client'
+import { usePresentationQuery, useIsPresentationTool } from 'next-sanity/hooks'
+
+export function Hero({ _key, documentId, ...initialProps }) {
+  const isPresentationTool = useIsPresentationTool()
+  const { data, loading } = usePresentationQuery({
+    query: HERO_PRESENTATION_QUERY,
+    params: { documentId, blockKey: _key },
+  })
+
+  console.log({
+    isPresentationTool,
+    loading,
+    hasData: !!data,
+    usingInitialProps: !data,
+  })
+
+  const block = data?.heroBlock || initialProps
+  // ...
+}
+```
+
+Reference: [Optimizing Visual Editing Performance](https://www.sanity.io/docs/visual-editing/introduction-to-visual-editing)

--- a/skills/sanity-nextjs-best-practices/rules/visual-editing-setup.md
+++ b/skills/sanity-nextjs-best-practices/rules/visual-editing-setup.md
@@ -1,0 +1,267 @@
+---
+title: Visual Editing Setup
+description: Configure Draft Mode, VisualEditing component, and Presentation Tool for click-to-edit
+tags: nextjs, visual-editing, draft-mode, presentation-tool, overlays
+---
+
+## Visual Editing Setup
+
+Visual Editing enables click-to-edit functionality in your Next.js preview. Editors can click any content in the preview to jump directly to that field in Sanity Studio.
+
+### How It Works
+
+1. **Content Source Maps (Stega)**: Sanity encodes document/field info as invisible characters in strings
+2. **Overlays**: The `VisualEditing` component renders clickable overlays on editable content
+3. **Presentation Tool**: Studio plugin that renders your site in an iframe with bidirectional navigation
+
+### Token Security
+
+Store your read token in a dedicated file that throws if missing. Never expose tokens in client bundles.
+
+**`src/sanity/lib/token.ts`:**
+
+```typescript
+export const token = process.env.SANITY_API_READ_TOKEN
+
+if (!token) {
+  throw new Error('Missing SANITY_API_READ_TOKEN')
+}
+```
+
+### App Router Setup
+
+**1. Enable Draft Mode API Route (`src/app/api/draft-mode/enable/route.ts`):**
+
+```typescript
+import { client } from '@/sanity/lib/client'
+import { token } from '@/sanity/lib/token'
+import { defineEnableDraftMode } from 'next-sanity/draft-mode'
+
+export const { GET } = defineEnableDraftMode({
+  client: client.withConfig({ token }),
+})
+```
+
+**2. Disable Draft Mode (`src/app/api/draft-mode/disable/route.ts`):**
+
+```typescript
+import { draftMode } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export async function GET() {
+  const draft = await draftMode()
+  draft.disable()
+  // Allow time for the cookie to be set
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  redirect('/')
+}
+```
+
+**3. Add VisualEditing to Layout (`src/app/layout.tsx`):**
+
+```typescript
+import { SanityLive } from '@/sanity/lib/live'
+import { VisualEditing } from 'next-sanity/visual-editing'
+import { draftMode } from 'next/headers'
+
+export default async function RootLayout({ 
+  children 
+}: { 
+  children: React.ReactNode 
+}) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <SanityLive />
+        {(await draftMode()).isEnabled && <VisualEditing />}
+      </body>
+    </html>
+  )
+}
+```
+
+### Disable Draft Mode Button
+
+Let editors exit preview mode when browsing outside the Presentation Tool:
+
+```typescript
+// src/components/DisableDraftMode.tsx
+'use client'
+import { useDraftModeEnvironment } from 'next-sanity/hooks'
+
+export function DisableDraftMode() {
+  const environment = useDraftModeEnvironment()
+  
+  // Only show outside of Presentation Tool
+  if (environment !== 'live' && environment !== 'unknown') return null
+
+  return (
+    <a 
+      href="/api/draft-mode/disable" 
+      className="fixed bottom-4 right-4 bg-gray-900 text-white px-4 py-2 rounded shadow-lg z-50"
+    >
+      Exit Draft Mode
+    </a>
+  )
+}
+```
+
+Add to layout:
+
+```typescript
+{(await draftMode()).isEnabled && (
+  <>
+    <DisableDraftMode />
+    <VisualEditing />
+  </>
+)}
+```
+
+### Presentation Tool Configuration
+
+Configure the Presentation Tool in your Studio config:
+
+**`sanity.config.ts`:**
+
+```typescript
+import { defineConfig } from 'sanity'
+import { presentationTool } from 'sanity/presentation'
+import { resolve } from '@/sanity/presentation/resolve'
+
+export default defineConfig({
+  // ...
+  plugins: [
+    presentationTool({
+      resolve,
+      previewUrl: {
+        previewMode: {
+          enable: '/api/draft-mode/enable',
+        },
+      },
+    }),
+  ],
+})
+```
+
+### Document Locations
+
+Tell the Presentation Tool where documents appear on your site:
+
+```typescript
+// src/sanity/presentation/resolve.ts
+import { 
+  defineLocations, 
+  PresentationPluginOptions 
+} from 'sanity/presentation'
+
+export const resolve: PresentationPluginOptions['resolve'] = {
+  locations: {
+    // Post documents
+    post: defineLocations({
+      select: { 
+        title: 'title', 
+        slug: 'slug.current' 
+      },
+      resolve: (doc) => ({
+        locations: [
+          { 
+            title: doc?.title || 'Untitled', 
+            href: `/blog/${doc?.slug}` 
+          },
+          { 
+            title: 'Blog index', 
+            href: '/blog' 
+          },
+        ],
+      }),
+    }),
+    
+    // Page documents
+    page: defineLocations({
+      select: { 
+        title: 'title', 
+        slug: 'slug.current' 
+      },
+      resolve: (doc) => ({
+        locations: doc?.slug === 'home'
+          ? [{ title: 'Homepage', href: '/' }]
+          : [{ title: doc?.title || 'Untitled', href: `/${doc?.slug}` }],
+      }),
+    }),
+    
+    // Settings singleton
+    settings: defineLocations({
+      message: 'This document is used on all pages',
+      tone: 'caution',
+    }),
+  },
+}
+```
+
+### Embedded Studio Setup
+
+Mount the Studio on a Next.js route:
+
+**`src/app/studio/[[...tool]]/page.tsx`:**
+
+```typescript
+import { NextStudio } from 'next-sanity/studio'
+import config from '../../../../sanity.config'
+
+export const dynamic = 'force-static'
+
+export { metadata, viewport } from 'next-sanity/studio'
+
+export default function StudioPage() {
+  return <NextStudio config={config} />
+}
+```
+
+### Pages Router Setup
+
+For Pages Router, use Preview Mode instead of Draft Mode:
+
+**1. Preview API route** - See `data-fetching-pages-router.md`
+
+**2. Add visual editing to `_app.tsx`:**
+
+```typescript
+// pages/_app.tsx
+import { useRouter } from 'next/router'
+import { VisualEditing } from 'next-sanity/visual-editing'
+
+export default function App({ Component, pageProps }) {
+  const router = useRouter()
+  const { preview } = pageProps
+
+  return (
+    <>
+      <Component {...pageProps} />
+      {preview && <VisualEditing />}
+    </>
+  )
+}
+```
+
+### Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Overlays not appearing | Check `VisualEditing` is rendered in draft mode |
+| Click-to-edit not working | Ensure stega encoding is enabled in client config |
+| "Invalid token" error | Verify `SANITY_API_READ_TOKEN` is set correctly |
+| CORS errors | Add your site URL to CORS origins in Sanity |
+| Preview shows published content | Check client is using token and correct perspective |
+
+### Environment Variables
+
+Required for Visual Editing:
+
+```env
+# .env.local
+SANITY_API_READ_TOKEN=sk...      # Viewer or Editor token
+SANITY_PREVIEW_SECRET=mysecret   # For Preview Mode (Pages Router)
+```
+
+Reference: [Visual Editing documentation](https://www.sanity.io/docs/visual-editing/introduction-to-visual-editing)

--- a/skills/sanity-nextjs-best-practices/rules/visual-editing-stega.md
+++ b/skills/sanity-nextjs-best-practices/rules/visual-editing-stega.md
@@ -1,0 +1,249 @@
+---
+title: Stega Clean for Logic Operations
+description: Use stegaClean() before string comparisons, object lookups, or metadata
+tags: nextjs, visual-editing, stega, stegaClean, metadata, seo
+---
+
+## Stega Clean for Logic Operations
+
+When Visual Editing is enabled, Sanity injects invisible characters (Stega) into string fields. These characters enable click-to-edit but **break string comparisons and lookups**.
+
+### The Golden Rule
+
+**Clean before logic, preserve for display.**
+
+| Use Case | Clean? | Why |
+|----------|--------|-----|
+| String comparison (`if (x === 'y')`) | Yes | Stega breaks equality |
+| Object key lookup (`map[value]`) | Yes | Keys won't match |
+| HTML IDs/attributes | Yes | Invalid characters |
+| CSS class mapping | Yes | Lookups fail |
+| Third-party APIs | Yes | May validate input |
+| Rendering text (`<h1>{title}</h1>`) | No | Breaks click-to-edit |
+| Passing to `<PortableText />` | No | Handles internally |
+| Image URL helpers | No | Handles internally |
+
+### Import stegaClean
+
+```typescript
+// From next-sanity (recommended for Next.js)
+import { stegaClean } from 'next-sanity'
+
+// Or from @sanity/client
+import { stegaClean } from '@sanity/client/stega'
+```
+
+### Pattern: String Comparisons
+
+**Incorrect (comparison fails):**
+
+```typescript
+function Layout({ align }: { align: string }) {
+  // This will NEVER match because align contains invisible characters
+  if (align === 'center') {
+    return <div className="mx-auto">...</div>
+  }
+  return <div>...</div>
+}
+```
+
+**Correct (clean first):**
+
+```typescript
+import { stegaClean } from 'next-sanity'
+
+function Layout({ align }: { align: string }) {
+  const cleanAlign = stegaClean(align)
+  
+  return (
+    <div className={cleanAlign === 'center' ? 'mx-auto' : ''}>
+      ...
+    </div>
+  )
+}
+```
+
+### Pattern: Object Key Lookups
+
+**Incorrect (lookup returns undefined):**
+
+```typescript
+const colorMap = {
+  red: 'bg-red-500',
+  blue: 'bg-blue-500',
+  green: 'bg-green-500',
+}
+
+function Card({ color }: { color: string }) {
+  // color = "red" + invisible stega chars -> lookup fails
+  return <div className={colorMap[color]}>...</div>
+}
+```
+
+**Correct (clean before lookup):**
+
+```typescript
+import { stegaClean } from 'next-sanity'
+
+function Card({ color }: { color: string }) {
+  const cleanColor = stegaClean(color)
+  return <div className={colorMap[cleanColor] || 'bg-gray-500'}>...</div>
+}
+```
+
+### Pattern: Switch Statements
+
+```typescript
+import { stegaClean } from 'next-sanity'
+
+function Icon({ name }: { name: string }) {
+  switch (stegaClean(name)) {
+    case 'arrow':
+      return <ArrowIcon />
+    case 'check':
+      return <CheckIcon />
+    default:
+      return null
+  }
+}
+```
+
+### Critical: SEO Metadata
+
+**Never** let Stega characters into `<head>` tags. They will appear in search results and break SEO.
+
+**Incorrect (stega in metadata):**
+
+```typescript
+export async function generateMetadata({ params }) {
+  const { data } = await sanityFetch({
+    query: PAGE_QUERY,
+    params: await params,
+    // Stega is ON by default!
+  })
+  
+  // Title will contain invisible characters!
+  return { title: data.title }
+}
+```
+
+**Correct (disable stega for metadata):**
+
+```typescript
+export async function generateMetadata({ params }) {
+  const { data } = await sanityFetch({
+    query: PAGE_QUERY,
+    params: await params,
+    stega: false, // Disable stega for metadata
+  })
+  
+  return { 
+    title: data.title,
+    description: data.description,
+  }
+}
+```
+
+### Critical: Static Params
+
+When generating static params, disable stega and use published perspective:
+
+```typescript
+export async function generateStaticParams() {
+  const { data } = await sanityFetch({
+    query: SLUGS_QUERY,
+    perspective: 'published', // No drafts
+    stega: false,             // No stega encoding
+  })
+  
+  return data.map((slug) => ({ slug }))
+}
+```
+
+### Pattern: Data Attributes
+
+HTML data attributes used for styling or JS logic:
+
+```typescript
+import { stegaClean } from 'next-sanity'
+
+function Section({ theme }: { theme: string }) {
+  return (
+    <section data-theme={stegaClean(theme)}>
+      {/* CSS: [data-theme="dark"] { ... } */}
+    </section>
+  )
+}
+```
+
+### Pattern: URL Construction
+
+```typescript
+import { stegaClean } from 'next-sanity'
+
+function ExternalLink({ url, label }: { url: string; label: string }) {
+  return (
+    <a href={stegaClean(url)}>
+      {label} {/* Keep stega for click-to-edit on label */}
+    </a>
+  )
+}
+```
+
+### Pattern: Conditional Rendering
+
+```typescript
+import { stegaClean } from 'next-sanity'
+
+function Feature({ enabled, title }: { enabled: string; title: string }) {
+  // Clean boolean-like strings
+  if (stegaClean(enabled) !== 'true') {
+    return null
+  }
+  
+  return <h2>{title}</h2> // Keep stega in rendered text
+}
+```
+
+### Utility Function
+
+Create a reusable utility for common patterns:
+
+```typescript
+// src/lib/utils.ts
+import { stegaClean } from 'next-sanity'
+
+type AlignValue = 'left' | 'center' | 'right'
+
+export function getAlignClass(align?: string): string {
+  const clean = stegaClean(align) as AlignValue | undefined
+  
+  const alignMap: Record<AlignValue, string> = {
+    left: 'text-left',
+    center: 'text-center mx-auto',
+    right: 'text-right ml-auto',
+  }
+  
+  return alignMap[clean || 'left']
+}
+```
+
+### When NOT to Clean
+
+Keep stega characters when rendering visible text:
+
+```typescript
+function Hero({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <section>
+      {/* DO NOT clean - stega enables click-to-edit */}
+      <h1>{title}</h1>
+      {subtitle && <p>{subtitle}</p>}
+    </section>
+  )
+}
+```
+
+If you clean rendered text, editors lose the ability to click on it to edit.
+
+Reference: [Content Source Maps](https://www.sanity.io/docs/visual-editing/content-source-maps)


### PR DESCRIPTION
# Add Sanity + Next.js Best Practices Skill

### TL;DR

Added skill for building Next.js applications with Sanity, covering data fetching, visual editing, type safety, images, page builders, and SEO.

### What changed?

- Created a new skill `sanity-nextjs-best-practices` with detailed documentation on integration patterns
- Added rules for both App Router (Next.js 13+) and Pages Router implementations
- Included best practices for:
  - Data fetching with `defineLive` and `getStaticProps`
  - Visual Editing setup and Presentation Tool configuration
  - TypeGen workflow for type-safe queries
  - Image handling with `next/image` and Sanity's image pipeline
  - Page Builder block rendering patterns
  - SEO metadata, sitemaps, and Open Graph images

Each rule file contains detailed explanations, code examples showing incorrect and correct implementations, and additional context for edge cases.