### PR TITLE
fix: best practices skill refrencing rules incorrectly 

### DIFF
--- a/skills/sanity-best-practices/SKILL.md
+++ b/skills/sanity-best-practices/SKILL.md
@@ -57,8 +57,4 @@ Each rule file contains:
 
 ## Framework Integration
 
-Framework-specific guidance (Next.js, Astro, Remix, etc.) is available in the `rules/*.mdc` files in the repository root. The skill references them when relevant but doesn't duplicate content.
-
-## Full Compiled Document
-
-For the complete guide with all rules expanded: `AGENTS.md`
+Framework-specific guidance (Next.js, Astro, Remix, etc.) is available via the Sanity MCP server using `list_sanity_rules` and `get_sanity_rules` tool calls when available. If the MCP server is not configured, run `npx sanity@latest mcp configure` to set it up.


### PR DESCRIPTION
### TL;DR

Updated the Sanity best practices skill documentation to reference the MCP server for framework-specific guidance.

When rules are installed through `npx skills add https://github.com/sanity-io/agent-toolkit --skill sanity-best-practices` only the folder with that skill is copied. This skill file references the rules folder and AGENTS.md outside this folder, which confuses agents when using the skill as it doesn't exist for users.

### What changed?

- Removed references to `rules/*.mdc` files in the repository root
- Removed the "Full Compiled Document" section that referenced `AGENTS.md`
- Added information about accessing framework-specific guidance via the Sanity MCP server using `list_sanity_rules` and `get_sanity_rules` tool calls