### PR TITLE
fix: quote invalid YAML frontmatter in rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "gray-matter": "^4.0.3",
         "skills-ref": "^0.1.5"
       }
     },
@@ -29,6 +30,83 @@
         "node": ">=18"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -40,6 +118,30 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/skills-ref": {
@@ -57,6 +159,23 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
   "description": "AI agent resources for Sanity development",
   "private": true,
   "scripts": {
-    "validate": "skills-ref validate ./skills/sanity-best-practices && skills-ref validate ./skills/content-modeling-best-practices && skills-ref validate ./skills/seo-aeo-best-practices && skills-ref validate ./skills/content-experimentation-best-practices",
+    "validate": "skills-ref validate ./skills/sanity-best-practices && skills-ref validate ./skills/content-modeling-best-practices && skills-ref validate ./skills/seo-aeo-best-practices && skills-ref validate ./skills/content-experimentation-best-practices && node scripts/validate-rules.mjs",
+    "validate:rules": "node scripts/validate-rules.mjs",
     "validate:sanity": "skills-ref validate ./skills/sanity-best-practices",
     "validate:content-modeling": "skills-ref validate ./skills/content-modeling-best-practices",
     "validate:seo": "skills-ref validate ./skills/seo-aeo-best-practices",
     "validate:experimentation": "skills-ref validate ./skills/content-experimentation-best-practices"
   },
   "devDependencies": {
+    "gray-matter": "^4.0.3",
     "skills-ref": "^0.1.5"
   },
   "keywords": [

--- a/rules/sanity-groq.mdc
+++ b/rules/sanity-groq.mdc
@@ -1,6 +1,6 @@
 ---
 description: Guidelines for GROQ queries, type safety, performance optimization, and syntax highlighting.
-globs: **/*.ts, **/*.tsx, **/*.js
+globs: "**/*.ts, **/*.tsx, **/*.js"
 alwaysApply: false
 ---
 

--- a/rules/sanity-image.mdc
+++ b/rules/sanity-image.mdc
@@ -1,6 +1,6 @@
 ---
-description: Best practices for handling images in Sanity: Schema, URL generation, and Next.js Image integration.
-globs: **/*.tsx, **/*.ts
+description: "Best practices for handling images in Sanity: Schema, URL generation, and Next.js Image integration."
+globs: "**/*.tsx, **/*.ts"
 alwaysApply: false
 ---
 

--- a/rules/sanity-page-builder.mdc
+++ b/rules/sanity-page-builder.mdc
@@ -1,6 +1,6 @@
 ---
 description: Patterns for Sanity Page Builder arrays, block components, and live editing.
-globs: **/*.tsx
+globs: "**/*.tsx"
 alwaysApply: false
 ---
 

--- a/rules/sanity-portable-text.mdc
+++ b/rules/sanity-portable-text.mdc
@@ -1,6 +1,6 @@
 ---
 description: Portable Text (Rich Text) rendering and custom component creation for React/Next.js.
-globs: **/*.tsx
+globs: "**/*.tsx"
 alwaysApply: false
 ---
 

--- a/scripts/validate-rules.mjs
+++ b/scripts/validate-rules.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that all .mdc rule files have valid YAML frontmatter.
+ * Run with: node scripts/validate-rules.mjs
+ */
+
+import {readdirSync, readFileSync} from 'fs'
+import {join, dirname} from 'path'
+import {fileURLToPath} from 'url'
+import matter from 'gray-matter'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+const rulesDir = join(rootDir, 'rules')
+
+const files = readdirSync(rulesDir).filter((f) => f.endsWith('.mdc'))
+let failed = false
+
+for (const file of files) {
+  const content = readFileSync(join(rulesDir, file), 'utf-8')
+  try {
+    const {data} = matter(content)
+    if (!data.description) {
+      console.error(`FAIL ${file}: missing 'description' in frontmatter`)
+      failed = true
+    } else {
+      console.log(`  OK ${file}`)
+    }
+  } catch (e) {
+    console.error(`FAIL ${file}: ${e.message.split('\n')[0]}`)
+    failed = true
+  }
+}
+
+if (failed) {
+  console.error('\nValidation failed. Ensure all frontmatter values with special characters (*, :) are quoted.')
+  process.exit(1)
+} else {
+  console.log(`\nAll ${files.length} rules validated successfully.`)
+}


### PR DESCRIPTION
## Summary

- Quotes frontmatter values containing YAML special characters in 4 `.mdc` rule files (`*` in globs, `: ` in description)
- Adds a `validate:rules` script using `gray-matter` to catch invalid frontmatter (also runs as part of `validate`)

## Context

These 5 values are invalid YAML that standard parsers (like `gray-matter`) reject:

| File | Field | Issue |
|---|---|---|
| `sanity-groq.mdc` | `globs` | Unquoted `*` (YAML alias indicator) |
| `sanity-image.mdc` | `globs` | Unquoted `*` |
| `sanity-image.mdc` | `description` | Unquoted `: ` (YAML mapping indicator) |
| `sanity-page-builder.mdc` | `globs` | Unquoted `*` |
| `sanity-portable-text.mdc` | `globs` | Unquoted `*` |

Cursor's own docs show `globs` as quoted values (`globs: ["src/components/**/*.tsx"]`), so quoting is the correct format.

## Test plan

- [x] `node scripts/validate-rules.mjs` passes for all 20 rules
- [ ] Verify Cursor still picks up globs correctly with quoted values