### PR TITLE
fix: quote description in image.md frontmatter

### DIFF
--- a/skills/sanity-best-practices/references/image.md
+++ b/skills/sanity-best-practices/references/image.md
@@ -1,6 +1,6 @@
 ---
 title: "Sanity Image Rules"
-description: Best practices for handling images in Sanity: Schema, URL generation, and Next.js Image integration.
+description: "Best practices for handling images in Sanity: Schema, URL generation, and Next.js Image integration."
 ---
 
 # Sanity Image Rules


### PR DESCRIPTION
## Summary
- Quotes the `description` field in `image.md` frontmatter to fix a YAML parsing error

The unquoted colon in `Sanity: Schema` causes `gray-matter` (which uses js-yaml 3.x `safeLoad`) to interpret it as a nested YAML mapping, breaking downstream consumers that parse this frontmatter.