### PR TITLE
feat: add OpenAI Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "sanity-agent-toolkit",
+  "interface": {
+    "displayName": "Sanity Agent Toolkit"
+  },
+  "plugins": [
+    {
+      "name": "sanity",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "sanity-agent-toolkit",
+  "name": "sanity",
   "interface": {
     "displayName": "Sanity Agent Toolkit"
   },

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "sanity",
       "source": {
-        "source": "local",
-        "path": "./"
+        "source": "url",
+        "url": "https://github.com/sanity-io/agent-toolkit.git"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -24,7 +24,7 @@
   "interface": {
     "displayName": "Sanity",
     "shortDescription": "Create, query, and manage structured content in Sanity",
-    "longDescription": "Create, query, and manage your structured content in Sanity directly from Codex. Run content audits, update documents, coordinate releases, and find anything across your projects. Or set up entirely new projects \u2014 schemas, content, and configuration \u2014 just by chatting with Codex.",
+    "longDescription": "Create, query, and manage your structured content in Sanity directly from Codex. Run content audits, update documents, coordinate releases, and find anything across your projects. Or set up entirely new projects - schemas, content, and configuration - just by chatting with Codex.",
     "developerName": "Sanity",
     "category": "Productivity",
     "capabilities": ["Interactive", "Read", "Write"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "sanity",
+  "version": "1.0.0",
+  "description": "Sanity plugin for Codex with MCP server and agent skills.",
+  "author": {
+    "name": "Sanity",
+    "email": "support@sanity.io",
+    "url": "https://www.sanity.io"
+  },
+  "homepage": "https://github.com/sanity-io/agent-toolkit",
+  "repository": "https://github.com/sanity-io/agent-toolkit",
+  "license": "MIT",
+  "keywords": [
+    "sanity",
+    "cms",
+    "content-lake",
+    "groq",
+    "content",
+    "structured-content",
+    "visual-editing"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Sanity",
+    "shortDescription": "Create, query, and manage structured content in Sanity",
+    "longDescription": "Create, query, and manage your structured content in Sanity directly from Codex. Run content audits, update documents, coordinate releases, and find anything across your projects. Or set up entirely new projects \u2014 schemas, content, and configuration \u2014 just by chatting with Codex.",
+    "developerName": "Sanity",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://www.sanity.io",
+    "privacyPolicyURL": "https://www.sanity.io/legal/privacy",
+    "termsOfServiceURL": "https://www.sanity.io/legal/tos",
+    "defaultPrompt": [
+      "Find all pages missing meta descriptions and list them by last updated date",
+      "Show me the 10 most recently published articles with author info",
+      "Create a Sanity schema for recipes with ingredients, instructions, and prep time"
+    ],
+    "brandColor": "#F03E2F",
+    "logo": "./assets/logo.svg"
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -36,7 +36,7 @@
       "Show me the 10 most recently published articles with author info",
       "Create a Sanity schema for recipes with ingredients, instructions, and prep time"
     ],
-    "brandColor": "#F03E2F",
+    "brandColor": "#FF5500",
     "logo": "./assets/logo.svg"
   }
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <h1 align="center">Sanity Agent Toolkit</h1>
 </p>
 
-Collection of resources to help AI agents build better with [Sanity](https://www.sanity.io). Supports Cursor, Claude Code, VS Code, Lovable, v0, and any other editor/agent compatible with MCP or [Agent Skills](https://agentskills.io).
+Collection of resources to help AI agents build better with [Sanity](https://www.sanity.io). Supports Cursor, Claude Code, Codex, VS Code, Lovable, v0, and any other editor/agent compatible with MCP or [Agent Skills](https://agentskills.io).
 
 ---
 
@@ -15,6 +15,7 @@ Collection of resources to help AI agents build better with [Sanity](https://www
 - **Agent skills:** Comprehensive best practices skills for Sanity development, content modeling, SEO/AEO, and experimentation. Includes 21 integration/topic guides and 26 focused best-practice rules.
 - **Claude Code plugin:** MCP server, agent skills, and slash commands for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) users.
 - **Cursor plugin:** MCP server, agent skills, and commands for the [Cursor Marketplace](https://cursor.com/marketplace).
+- **Codex plugin:** MCP server and agent skills for [OpenAI Codex](https://developers.openai.com/codex) users.
 
 ---
 
@@ -68,6 +69,21 @@ Or manually: Open **Command Palette** (`Cmd+Shift+P` / `Ctrl+Shift+P`) → **Vie
 Run in terminal. Authenticate with OAuth on next launch:
 ```bash
 claude mcp add Sanity -t http https://mcp.sanity.io --scope user
+```
+</details>
+
+<details>
+<summary><strong>Codex</strong></summary>
+
+Run in terminal. Authenticate with OAuth on next launch:
+```bash
+codex mcp add Sanity --url https://mcp.sanity.io
+```
+
+Or manually add to `~/.codex/config.toml`:
+```toml
+[mcp_servers.Sanity]
+url = "https://mcp.sanity.io"
 ```
 </details>
 
@@ -194,6 +210,18 @@ In Cursor chat, run:
 /add-plugin sanity
 ```
 
+#### Codex
+
+1. Add the Sanity marketplace:
+
+```bash
+codex plugin marketplace add sanity-io/agent-toolkit
+```
+
+2. Install the plugin from Codex's plugin directory (select the **Sanity Agent Toolkit** marketplace, then install **Sanity**).
+
+3. Restart Codex. Verify by asking: "which skills do you have access to?" — you should see the Sanity skills listed.
+
 ### Option 4: Manual installation
 
 Install the skill references locally to teach your editor Sanity best practices:
@@ -260,8 +288,12 @@ Just say: "Get started with Sanity" to begin.
 sanity-io/agent-toolkit/
 ├── AGENTS.md                      # Knowledge router & agent behavior
 ├── README.md                      # This file
+├── .agents/plugins/               # Codex marketplace
+│   └── marketplace.json           # Codex marketplace metadata
 ├── .claude-plugin/                # Claude Code plugin configuration
 │   └── marketplace.json           # Plugin metadata and marketplace config
+├── .codex-plugin/                 # Codex plugin configuration
+│   └── plugin.json                # Codex plugin manifest
 ├── .cursor-plugin/                # Cursor plugin configuration
 │   ├── marketplace.json           # Cursor marketplace metadata
 │   └── plugin.json                # Per-plugin manifest

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "agent",
     "skills",
     "claude",
-    "cursor"
+    "cursor",
+    "codex"
   ],
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

Make the agent-toolkit installable as an [OpenAI Codex](https://developers.openai.com/codex/plugins/build) plugin under the name `sanity`, alongside the existing Claude Code and Cursor plugins. Reuses the shared `skills/` and `.mcp.json` at the repo root \u2014 no changes to the Claude or Cursor plugin assets.

## Changes

- **`.codex-plugin/plugin.json`** \u2014 Codex plugin manifest. Points at `./skills/` and `./.mcp.json`. `interface` metadata (display copy, `category: Productivity`, `capabilities: [Interactive, Read, Write]`, brand color, logo, `defaultPrompt` chips) is modeled after the [Sanity Claude connector listing](https://www.anthropic.com/connectors) so the install surface looks consistent across editors.
- **`.agents/plugins/marketplace.json`** \u2014 Codex-native marketplace exposing a single `sanity` plugin entry with `policy.installation = AVAILABLE` and `policy.authentication = ON_INSTALL`.
- **`README.md`** \u2014 New Codex `<details>` block under \"Option 1: Install MCP server\" (with both `codex mcp add` and `~/.codex/config.toml` snippets) and a Codex subsection under \"Option 3: Install plugin\". Repo structure block updated.
- **`package.json`** \u2014 `codex` added to keywords.

## Out of scope

- No changes to `.claude-plugin/` or `.cursor-plugin/`. The legacy `sanity-plugin` name in the Claude marketplace stays as-is for backwards compatibility.
- No new validator script (Codex doesn't have a published JSON schema yet, and `npm run validate:all` continues to pass unchanged).
- No port of `commands/*.md` into Codex skills \u2014 Codex's plugin model doesn't include slash commands; the existing skills already cover the same surface area.

## Test plan

- [x] `npm run validate:all` passes (skill validators + Cursor plugin validator unchanged).
- [x] Manual smoke test: from the repo root, `codex plugin marketplace add ./` then verify `Sanity` appears under the **Sanity Agent Toolkit** marketplace in Codex's plugin directory and installs cleanly.
- [x] After install, verify the bundled skills (`sanity-best-practices`, `content-modeling-best-practices`, `seo-aeo-best-practices`, `content-experimentation-best-practices`, `portable-text-serialization`, `portable-text-conversion`) are discoverable by asking Codex \"which skills do you have access to?\"
- [x] Verify the bundled Sanity MCP server is reachable (try one of the `defaultPrompt` chips).