### PR TITLE
fix: rename /review slash command to /sanity-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Just say: "Get started with Sanity" to begin.
 | Command | What it does |
 | :--- | :--- |
 | `/sanity` | List available skills and help topics |
-| `/review` | Review code for Sanity best practices |
+| `/sanity-review` | Review code for Sanity best practices |
 | `/typegen` | Run TypeGen and troubleshoot issues |
 | `/deploy-schema` | Deploy schema with verification |
 
@@ -302,7 +302,7 @@ sanity-io/agent-toolkit/
 │   └── logo.svg                   # Sanity logo for marketplace display
 ├── commands/                      # Agent commands
 │   ├── sanity.md                  # /sanity help
-│   ├── review.md                  # /review
+│   ├── sanity-review.md           # /sanity-review
 │   ├── typegen.md                 # /typegen
 │   └── deploy-schema.md           # /deploy-schema
 ├── scripts/                       # Validation and CI scripts

--- a/commands/sanity-review.md
+++ b/commands/sanity-review.md
@@ -1,5 +1,5 @@
 ---
-name: review
+name: sanity-review
 description: Review code for Sanity best practices and common issues.
 ---
 
@@ -51,4 +51,3 @@ Just ask me to review specific files or your whole Sanity setup:
 > "Review my post schema"
 > "Check my GROQ queries for issues"
 > "Review my Sanity frontend integration"
-


### PR DESCRIPTION
## Summary

- Renames `commands/review.md` to `commands/sanity-review.md`, changing the slash command from `/review` to `/sanity-review`
- Updates README documentation to reflect the new command name

Fixes the collision with other Claude Code plugins (notably CodeRabbit) that also register `/review` in the shared flat slash-command namespace. The other Sanity commands (`/sanity`, `/typegen`, `/deploy-schema`) are already well-namespaced — review was the odd one out.

## Test plan

- [x] Install the Sanity Claude Code plugin alongside CodeRabbit
- [x] Type `/sanity-review` and confirm only the Sanity code review command appears
- [x] Confirm `/review` no longer registers from the Sanity plugin
- [x] Verify the command still runs the same Sanity best-practices review workflow


Made with [Cursor](https://cursor.com)