### PR TITLE
docs: discourage deterministic Sanity document IDs

### DIFF
--- a/skills/sanity-best-practices/SKILL.md
+++ b/skills/sanity-best-practices/SKILL.md
@@ -24,6 +24,12 @@ Reference these guidelines when:
 - Managing infrastructure with Blueprints
 - Automating content workflows with Sanity Functions
 
+## Global Rules
+
+- Let Sanity generate `_id` values for ordinary documents. Do not create deterministic UUIDs, slug-derived IDs, or legacy-system IDs when creating documents.
+- Model relationships with `reference` fields, then resolve related documents with GROQ lookups, source-key fields, or returned `_id` values from created documents.
+- Use explicit document IDs mainly for singleton documents controlled by Studio Structure, including localized singletons such as `homePage-en`.
+
 ## Quick Reference
 
 ### Integration Guides
@@ -71,4 +77,3 @@ Each reference file contains:
 - Incorrect and correct code examples
 - Decision matrices and workflow guidance
 - Framework-specific patterns where applicable
-

--- a/skills/sanity-best-practices/references/functions.md
+++ b/skills/sanity-best-practices/references/functions.md
@@ -441,8 +441,7 @@ export const handler = documentEventHandler(async ({ context, event }) => {
     documentId: event.data._id,
     languageFieldPath: 'language',
     targetDocument: {
-      operation: 'createOrReplace',
-      _id: `${event.data._id}-el-GR`,
+      operation: 'create',
     },
     fromLanguage: { id: 'en-US', title: 'English' },
     toLanguage: { id: 'el-GR', title: 'Greek' },
@@ -451,6 +450,8 @@ export const handler = documentEventHandler(async ({ context, event }) => {
 ```
 
 The GROQ filter ensures only English documents trigger the function. The translated document gets a different `language` value, preventing recursive triggers.
+
+Let Sanity assign the translated document's `_id` for ordinary localized content. To find or update translations later, query by language, slug, or translation metadata instead of deriving IDs from the source document. Reserve explicit `targetDocument._id` values for singleton-style targets.
 
 ### Auto-tag with Agent Actions
 

--- a/skills/sanity-best-practices/references/localization.md
+++ b/skills/sanity-best-practices/references/localization.md
@@ -300,7 +300,7 @@ export const structure: StructureResolver = (S) =>
 
 ### Key Points
 
-- **Fixed IDs:** Use `${typeName}-${locale}` pattern for predictable document IDs
+- **Fixed IDs:** Use `${typeName}-${locale}` only for localized singletons; let Sanity generate IDs for ordinary localized content
 - **Initial Value Templates:** Essential for the "New document" menu to work correctly
 - **Structure:** Group all locale versions under one list item for cleaner navigation
 - **See also:** `studio-structure.md` for more singleton patterns

--- a/skills/sanity-best-practices/references/migration-html-import.md
+++ b/skills/sanity-best-practices/references/migration-html-import.md
@@ -105,11 +105,11 @@ async function uploadImage(client, imageUrl) {
 
 ### Using in a Migration
 
-Wrap this in `defineMigration` for reproducible imports:
+Wrap this in `defineMigration` for controlled imports:
 
 ```typescript
 // migrations/import-wordpress-posts/index.ts
-import {defineMigration, createOrReplace} from 'sanity/migrate'
+import {defineMigration, create} from 'sanity/migrate'
 import {htmlToBlocks} from '@portabletext/block-tools'
 
 export default defineMigration({
@@ -122,16 +122,19 @@ export default defineMigration({
         parseHtml: html => new JSDOM(html).window.document,
       })
       
-      yield createOrReplace({
-        _id: `post-${post.slug}`,
+      yield create({
         _type: 'post',
         title: post.title,
+        slug: {_type: 'slug', current: post.slug},
+        legacyId: String(post.id),
         body: blocks,
       })
     }
   }
 })
 ```
+
+Let Sanity generate document IDs for ordinary imported content. Add schema fields for legacy identifiers or slugs, then use GROQ lookups against those fields when you need to rerun an import, patch existing documents, or create references between imported records. Set `_id` directly only for singleton documents.
 
 Run with: `sanity migration run import-wordpress-posts --no-dry-run`
 

--- a/skills/sanity-best-practices/references/migration.md
+++ b/skills/sanity-best-practices/references/migration.md
@@ -5,6 +5,15 @@ description: Best practices for migrating content (HTML, Markdown) into Sanity P
 
 # Sanity Content Migration Rules
 
+## Document Identity During Import (Critical)
+
+Let Sanity generate `_id` values for imported documents unless you are intentionally creating a singleton. Do not derive deterministic UUIDs or document IDs from slugs, file paths, legacy IDs, or related document IDs.
+
+- Store legacy identifiers in fields such as `legacyId`, `externalId`, or `slug`.
+- Make imports idempotent by looking up existing documents with GROQ before creating or patching them.
+- Create relationships by querying the target document and using its real `_id` in a `reference`; do not predict `_ref` values from naming conventions.
+- Reserve explicit `_id` values for singleton documents such as `settings`, `homePage`, or localized singleton IDs like `homePage-en`.
+
 ## 1. HTML Import (Legacy CMS)
 Use `@portabletext/block-tools` with `JSDOM` to convert HTML to Portable Text. This covers setup, custom deserializers, pre-processing, image uploads, and wrapping in `defineMigration`.
 

--- a/skills/sanity-best-practices/references/schema.md
+++ b/skills/sanity-best-practices/references/schema.md
@@ -14,6 +14,7 @@ Use this contents list to jump to the schema design decision you are making.
 - Shared fields pattern
 - Field patterns
 - References vs nested objects
+- Document creation and IDs
 - Safe schema updates
 - Validation patterns
 
@@ -221,7 +222,46 @@ defineField({
 *[_type == "post"]{ seo { title, description } }
 ```
 
-## 6. Safe Schema Updates (The Deprecation Pattern)
+## 6. Document Creation and IDs
+
+Sanity document `_id` values are implementation identifiers, not a content modeling tool.
+
+- **Prefer generated IDs:** Let Sanity assign `_id` values for ordinary content documents. Avoid deterministic UUIDs, slug-derived IDs, and IDs copied from legacy systems.
+- **Use relationships, not ID conventions:** Connect documents with `reference` fields and set `_ref` from an actual lookup or from the `_id` returned after creating the related document.
+- **Store source identity as content:** For imports, put legacy IDs, external IDs, or stable slugs in explicit fields such as `legacyId`, `externalId`, or `slug`, then query by those fields when you need to find or upsert content.
+- **Keep explicit IDs rare:** Directly setting `_id` is mainly useful for singleton documents managed through Studio Structure, such as `settings` or localized singletons like `homePage-en`.
+
+```typescript
+// ✅ Correct - relationship comes from a lookup
+import {defineQuery} from 'groq'
+
+const AUTHOR_BY_EXTERNAL_ID_QUERY = defineQuery(`
+  *[_type == "author" && externalId == $externalId][0]{_id}
+`)
+
+const author = await client.fetch(AUTHOR_BY_EXTERNAL_ID_QUERY, {
+  externalId: post.authorId,
+})
+
+if (!author?._id) throw new Error(`Missing author for ${post.authorId}`)
+
+await client.create({
+  _type: 'post',
+  title: post.title,
+  slug: {_type: 'slug', current: post.slug},
+  legacyId: post.id,
+  author: {_type: 'reference', _ref: author._id},
+})
+
+// ❌ Wrong - IDs encode relationships and source data
+await client.createOrReplace({
+  _id: `post-${post.id}`,
+  _type: 'post',
+  author: {_type: 'reference', _ref: `author-${post.authorId}`},
+})
+```
+
+## 7. Safe Schema Updates (The Deprecation Pattern)
 
 **NEVER** delete a field that contains production data. It will cause data loss or Studio crashes. Instead, follow the **ReadOnly -> Hidden -> Deprecated** lifecycle.
 
@@ -281,7 +321,7 @@ sanity migration run rename-oldTitle-to-newTitle --no-dry-run
 
 **Phase 3: Remove** — Once `oldTitle` is undefined for all documents, delete the field definition.
 
-## 7. Validation Patterns
+## 8. Validation Patterns
 
 Beyond `rule.required()`, Sanity offers powerful validation options.
 

--- a/skills/sanity-best-practices/references/studio-structure.md
+++ b/skills/sanity-best-practices/references/studio-structure.md
@@ -45,6 +45,8 @@ export const structure: StructureResolver = (S) =>
 
 **Singletons are enforced via Structure, NOT schema options.** There is no `singleton: true` schema option.
 
+This is the main case where explicit document IDs are appropriate. For ordinary content documents, let Sanity generate `_id` values and use references or GROQ lookups to connect records.
+
 ### How Singletons Work
 1. Use `S.document().documentId('fixed-id')` to lock the document to a specific ID.
 2. Filter the type from generic lists to prevent duplicate entries.


### PR DESCRIPTION
## Summary
- add global guidance to avoid deterministic UUIDs and slug-derived document IDs
- document lookup/reference patterns for imports and relationships
- clarify that explicit IDs are mainly for singleton and localized singleton documents

## Verification
- npm run validate:sanity
- git diff --check