### PR TITLE
docs(skill): recommend standalone Studio over embedded for Next.js

### DIFF
--- a/skills/sanity-best-practices/SKILL.md
+++ b/skills/sanity-best-practices/SKILL.md
@@ -35,14 +35,14 @@ Reference these guidelines when:
 ### Integration Guides
 
 - `get-started` - Interactive onboarding for new Sanity projects
-- `nextjs` - Next.js App Router, Live Content API, embedded Studio
+- `nextjs` - Next.js App Router, Live Content API, standalone Studio
 - `nuxt` - Nuxt integration with @nuxtjs/sanity
 - `angular` - Angular integration with @sanity/client, signals, resource API
 - `astro` - Astro integration with @sanity/astro
 - `remix` - React Router / Remix integration
 - `svelte` - SvelteKit integration with @sanity/svelte-loader
 - `hydrogen` - Shopify Hydrogen with Sanity
-- `project-structure` - Monorepo and embedded Studio patterns
+- `project-structure` - Standalone Studio and monorepo patterns
 - `app-sdk` - Custom applications with Sanity App SDK
 - `blueprints` - Infrastructure as Code with Sanity Blueprints
 - `functions` - Automating content workflows with Sanity Functions

--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -35,7 +35,7 @@ Getting started with Sanity follows three phases:
 **Before starting:** Let the user know they can pause and resume anytime by saying "Continue Sanity setup".
 
 **RESUME TRIGGER:** If the user says "Continue Sanity setup", check what's already configured:
-- Does `sanity.config.ts` exist? → Studio is set up
+- Does `sanity.config.ts` exist (typically in a `studio/` folder)? → Studio is set up
 - Are there files in `schemaTypes/`? → Schema exists
 - Is there a frontend framework in `package.json`? → May need integration
 
@@ -51,10 +51,11 @@ Resume from where they left off.
 
 **If NO Studio found:**
 - Ask: "Want to create a new Sanity Studio?"
-- If yes, run:
+- If yes, run from the repo root — **not inside a Next.js app folder**, where the CLI would switch to its embedded flow (not recommended):
   ```bash
-  npm create sanity@latest -- --template clean --typescript
+  npm create sanity@latest -- --template clean --typescript --output-path studio
   ```
+- This creates a standalone Studio in `studio/`, alongside your app folder (see `project-structure.md`)
 
 **If Studio exists:**
 - Read the config to get `projectId` and `dataset`
@@ -217,9 +218,12 @@ This trap is invisible at SSR — the page renders fine on first load. It surfac
 If Next.js is detected, follow these essential steps:
 
 **Scaffold a new app (if you don't have one yet):**
+
+Run from the repo root so the app sits alongside your `studio/` folder:
+
 ```bash
-npx create-next-app@latest my-app --tailwind --ts --app --src-dir --eslint --import-alias "@/*" --turbopack
-cd my-app
+npx create-next-app@latest web --tailwind --ts --app --src-dir --eslint --import-alias "@/*" --turbopack
+cd web
 ```
 
 **Install dependencies:**
@@ -233,7 +237,7 @@ npm install next-sanity @sanity/image-url
 - `next-sanity/draft-mode` — Draft Mode endpoint helpers
 - `next-sanity/visual-editing` — `<VisualEditing />` component for click-to-edit overlays
 - `next-sanity/image` — Sanity-aware `<Image />` wrapping `next/image`
-- `next-sanity/studio` — embed the Sanity Studio at a route
+- `next-sanity/studio` — embed the Sanity Studio at a route (legacy setups only — keep the Studio standalone, see `nextjs.md`)
 - `next-sanity/webhook` — webhook signature verification
 
 Don't also install `@sanity/client`, `@portabletext/react`, or `groq` directly — import them from `next-sanity`. `@sanity/image-url` is not bundled (yet), so add it separately.
@@ -316,7 +320,7 @@ NEXT_PUBLIC_SANITY_PROJECT_ID=your-project-id
 NEXT_PUBLIC_SANITY_DATASET=production
 ```
 
-For advanced patterns (TypeGen, Visual Editing with `next-sanity/visual-editing`, live content with `defineLive` from `next-sanity/live`, embedded Studio via `next-sanity/studio`), see `nextjs.md`.
+For advanced patterns (TypeGen, Visual Editing with `next-sanity/visual-editing`, live content with `defineLive` from `next-sanity/live`, standalone Studio architecture), see `nextjs.md`.
 
 ### Step 3: Other Frameworks
 

--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -47,7 +47,7 @@ Resume from where they left off.
 
 ### Step 1: Check for Existing Studio
 
-**Look for `sanity.config.ts` or `sanity.cli.ts`:**
+**Look for `sanity.config.ts` or `sanity.cli.ts` across the workspace** — in the recommended side-by-side layout the Studio lives in its own folder (`studio/`, or `studio-*` when created by the Sanity onboarding flow) next to the app folder:
 
 **If NO Studio found:**
 - Ask: "Want to create a new Sanity Studio?"
@@ -197,9 +197,11 @@ For secrets (read tokens, webhook secrets), read `process.env.*` (or the server 
 
 This trap is invisible at SSR — the page renders fine on first load. It surfaces on client-side route transitions, when a lazy-loaded route chunk pulls a shared client/image module into the browser.
 
-### Step 1: Detect Framework
+### Step 1: Find the App and Detect Framework
 
-**Check `package.json` dependencies:**
+The working directory is often a parent folder with the Studio and the app side by side. Identify the app folder first: a sibling of the Studio folder with its own `package.json` (commonly `web/`). If several candidates exist, ask the user which app to integrate — never assume.
+
+**Check the app's `package.json` dependencies:**
 
 | Dependency | Framework | Rule File |
 |------------|-----------|-----------|
@@ -337,7 +339,7 @@ Each rule file contains framework-specific patterns for data fetching, Portable 
 
 Before declaring integration done, exercise both render paths:
 
-1. `npm run dev`
+1. `npm run dev` (in the app folder)
 2. Load the home page (lists posts).
 3. **Click through to a detail page** via an in-app `<Link>` / `<a>` — do not paste the URL.
 4. Open the browser console. It should be clean. No `ReferenceError: process is not defined`, no hard reload to `/`.

--- a/skills/sanity-best-practices/references/nextjs.md
+++ b/skills/sanity-best-practices/references/nextjs.md
@@ -1,6 +1,6 @@
 ---
 title: Next.js & Sanity Integration Rules
-description: Integration guide for Next.js App Router, Live Content API, and Sanity Studio (Embedded or Standalone).
+description: Integration guide for Next.js App Router, Live Content API, and a standalone Sanity Studio.
 ---
 
 # Next.js & Sanity Integration Rules
@@ -13,7 +13,7 @@ Jump to the section that matches the task instead of reading this guide end-to-e
 - Data fetching (Live Content API)
 - Caching and revalidation
 - Visual Editing and clean data
-- Embedded Studio setup
+- Studio setup (standalone)
 - Draft Mode setup
 - Error handling
 - Presentation queries
@@ -21,25 +21,31 @@ Jump to the section that matches the task instead of reading this guide end-to-e
 
 ## 1. Architecture Patterns
 
-### Option A: Embedded Studio (Recommended)
-**Best for:** Most Next.js projects. Unified deployment, simpler setup.
+### Option A: Standalone Studio (Recommended)
+**Best for:** All new Next.js projects.
 
-The Studio lives inside your Next.js app at `/app/studio/[[...tool]]/page.tsx`.
-- **Config:** `sanity.config.ts` lives in the project root.
-- See `project-structure.md` rule for detailed structure.
+The Studio is its own app, living alongside the Next.js app in the same repo:
 
-### Option B: Monorepo (Alternative)
-**Best for:** Separation of concerns, multiple frontends, or strict dependency isolation.
-
-The Studio and Next.js app live in separate folders:
 ```
-apps/
+your-project/
 ├── studio/     # Sanity Studio (standalone)
 └── web/        # Next.js frontend
 ```
 
-- **Config:** Add your Next.js app URL to **CORS Origins** in [Sanity Manage](https://www.sanity.io/manage).
+Why standalone instead of embedding the Studio in the Next.js app:
+
+- **Faster dev and builds:** `sanity dev` and `sanity build` run on Vite and are dramatically faster (10-30x) than compiling the Studio through `next dev` / `next build`.
+- **Auto-updates:** Standalone Studios receive bugfixes and new features automatically, with no dependency bump or redeploy. Embedded Studios can't auto-update (Next.js does not support ESM with import maps), so every update means bump + deploy.
+- **TypeGen watch mode:** With `sanity dev`, TypeGen regenerates types as queries change. Embedded Studios can't hook into `next dev`, so you must re-run `sanity typegen generate` manually after every query edit.
+- **Content model independence:** A separate Studio keeps the content model from becoming website-centric and makes collaboration easier.
+
+**Setup:**
+- Run both apps side by side in separate terminals: `next dev` (localhost:3000) and `sanity dev` (localhost:3333).
+- Add your Next.js app URL to **CORS Origins**: `npx sanity cors add http://localhost:3000 --credentials` (repeat for your production URL), or via [Sanity Manage](https://www.sanity.io/manage).
 - See `project-structure.md` rule for detailed structure.
+
+### Option B: Embedded Studio (Not Recommended)
+The Studio can be mounted inside the Next.js app at `/app/studio/[[...tool]]/page.tsx` via `next-sanity/studio`. Avoid this for new projects: it slows builds, ties every Studio update to an app deploy, and rules out auto-updates and TypeGen watch mode. For maintaining or migrating an existing embedded Studio, see section 5.
 
 ## 2. Data Fetching (Live Content API)
 
@@ -332,23 +338,24 @@ export async function generateStaticParams() {
 }
 ```
 
-## 5. Setup: Embedded Studio
+## 5. Setup: Studio (Standalone)
 
-Mount the Studio on a Next.js route.
+Create the Studio as its own app from the repo root — **not inside the Next.js app folder**, where the CLI would switch to its embedded flow:
 
-**`src/app/studio/[[...tool]]/page.tsx`:**
-
-```typescript
-import { NextStudio } from 'next-sanity/studio'
-import config from '../../../../sanity.config'
-
-export const dynamic = 'force-static'
-export { metadata, viewport } from 'next-sanity/studio'
-
-export default function StudioPage() {
-  return <NextStudio config={config} />
-}
+```bash
+npm create sanity@latest -- --project <projectId> --dataset production --template clean --typescript --output-path studio
 ```
+
+Run it with `npm run dev` inside `studio/` (defaults to http://localhost:3333). For Visual Editing, point the Presentation Tool's `previewUrl.origin` at the Next.js app (see `visual-editing.md`).
+
+### Migrating an Existing Embedded Studio
+
+Embedded Studios (`<NextStudio />` mounted at a route like `/app/studio/[[...tool]]/page.tsx`) keep working, but migrating to a standalone Studio is recommended:
+
+1. Create a standalone Studio folder as above, reusing your existing `projectId` and dataset.
+2. Move `sanity.config.ts`, `sanity.cli.ts`, and your schema types into it.
+3. Delete the `/app/studio/[[...tool]]/` route from the Next.js app. Keep `next-sanity` — the app still needs it for fetching, Live Content, and Visual Editing.
+4. Add the app's URLs to CORS origins and set the Presentation Tool's `previewUrl.origin` to the app's URL.
 
 ## 6. Setup: Draft Mode
 

--- a/skills/sanity-best-practices/references/project-structure.md
+++ b/skills/sanity-best-practices/references/project-structure.md
@@ -1,6 +1,6 @@
 ---
 title: Sanity Project Structure
-description: Project structure patterns for Sanity projects including monorepo and embedded Studio setups.
+description: Project structure patterns for Sanity projects including standalone Studio and monorepo setups.
 ---
 
 # Sanity Project Structure
@@ -26,62 +26,42 @@ your-project/
 - Headless CMS with external consumers
 - Prototyping and content design
 
-## Embedded Studio (Recommended for Next.js)
+## Monorepo (Recommended with a frontend)
 
-Best for most Next.js projects. Unified deployment, simpler setup.
-
-```
-your-project/
-├── src/
-│   ├── app/                    # Next.js App Router
-│   │   └── studio/[[...tool]]/ # Embedded Studio route
-│   └── sanity/
-│       ├── lib/
-│       │   ├── client.ts
-│       │   ├── live.ts         # defineLive setup
-│       │   └── queries.ts
-│       └── schemaTypes/
-│           ├── index.ts
-│           ├── documents/
-│           ├── objects/
-│           └── blocks/
-├── sanity.config.ts
-├── sanity.cli.ts               # CLI + TypeGen configuration
-└── sanity.types.ts             # Generated types (from TypeGen)
-```
-
-## Monorepo
-
-Best when you need separation of concerns, multiple frontends, or strict dependency isolation.
+Best for most projects pairing Sanity with a Next.js (or other framework) app. The Studio stays standalone — Vite-based dev/builds, auto-updates, TypeGen watch mode — while living in the same repo as the frontend.
 
 ```
 your-project/
-├── apps/
-│   ├── studio/                 # Sanity Studio (standalone)
-│   │   ├── src/
-│   │   │   └── schemaTypes/
-│   │   │       ├── index.ts
-│   │   │       ├── documents/
-│   │   │       ├── objects/
-│   │   │       └── blocks/
-│   │   ├── sanity.config.ts
-│   │   ├── sanity.cli.ts
-│   │   └── package.json
-│   └── web/                    # Next.js (or other framework)
-│       ├── src/
-│       │   ├── app/
-│       │   └── sanity/
-│       │       ├── client.ts
-│       │       ├── live.ts
-│       │       └── queries.ts
-│       └── package.json
-├── pnpm-workspace.yaml
-└── package.json
+├── studio/                     # Sanity Studio (standalone)
+│   ├── schemaTypes/
+│   │   ├── index.ts
+│   │   ├── documents/
+│   │   ├── objects/
+│   │   └── blocks/
+│   ├── sanity.config.ts
+│   ├── sanity.cli.ts           # CLI + TypeGen configuration
+│   └── package.json
+└── web/                        # Next.js (or other framework)
+    ├── src/
+    │   ├── app/
+    │   └── sanity/
+    │       ├── client.ts
+    │       ├── live.ts         # defineLive setup
+    │       └── queries.ts
+    ├── sanity.types.ts         # Generated types (from TypeGen)
+    └── package.json
 ```
+
+No workspace tooling is required — each app manages its own dependencies. For larger repos, the same shape works under `apps/` with npm or pnpm workspaces.
 
 **Setup:**
-1. Add web app URL to CORS origins in [Sanity Manage](https://www.sanity.io/manage)
-2. Configure `typegen` in `sanity.cli.ts` to read schema from `apps/studio` and output types to `apps/web`
+1. Add the web app URL to CORS origins: `npx sanity cors add http://localhost:3000 --credentials` (or via [Sanity Manage](https://www.sanity.io/manage))
+2. Configure `typegen` in `studio/sanity.cli.ts` to read queries from `../web` and output types to `../web/sanity.types.ts` (see `typegen.md`)
+3. Optionally add a root `package.json` with scripts that run both dev servers
+
+## Embedded Studio (Legacy — Not Recommended)
+
+Older Next.js projects may mount the Studio inside the app at `src/app/studio/[[...tool]]/page.tsx`, with `sanity.config.ts` in the app root. This still works but is no longer recommended: it slows builds, ties Studio updates to app deploys, and rules out auto-updates and TypeGen watch mode. See `nextjs.md` for the rationale and migration steps.
 
 ## File Naming Conventions
 

--- a/skills/sanity-best-practices/references/typegen.md
+++ b/skills/sanity-best-practices/references/typegen.md
@@ -92,10 +92,7 @@ export default defineCliConfig({
 
 ### Project Structure Examples
 
-**Single Repo / Embedded Studio (most common):**
-Use defaults — no extra config needed.
-
-**Monorepo** (Studio in `apps/studio`, Frontend in `apps/web`):
+**Monorepo (recommended)** (Studio in `studio/`, Frontend in `web/` — same config works under `apps/`):
 ```typescript
 export default defineCliConfig({
   typegen: {
@@ -105,6 +102,9 @@ export default defineCliConfig({
   },
 })
 ```
+
+**Single Repo / Embedded Studio (legacy):**
+Use defaults — no extra config needed.
 
 **Separate Repos:**
 Use `--watch` mode in your frontend: `sanity typegen generate --watch`

--- a/skills/sanity-best-practices/references/visual-editing.md
+++ b/skills/sanity-best-practices/references/visual-editing.md
@@ -75,6 +75,8 @@ export default defineConfig({
     presentationTool({
       resolve, // Document locations (see below)
       previewUrl: {
+        // The front-end origin — required when the Studio runs standalone
+        origin: process.env.SANITY_STUDIO_PREVIEW_ORIGIN || 'http://localhost:3000',
         previewMode: {
           enable: '/api/draft-mode/enable',
         },


### PR DESCRIPTION
## Summary

- Flips the Next.js architecture recommendation from embedded Studio to a standalone Studio in a simple monorepo layout (`studio/` + `web/`), aligning the skill with the new onboarding flow.
- Documents why standalone wins: `sanity dev`/`sanity build` run on Vite (10-30x faster than compiling the Studio through `next dev`/`next build`), Studio auto-updates only work standalone (Next.js does not support ESM with import maps), TypeGen watch mode only works with `sanity dev`, and a separate Studio keeps the content model from becoming website-centric.
- `nextjs.md`: standalone Studio is now Option A with rationale and CORS setup; the embedded Studio setup section is replaced with standalone setup plus migration steps for existing embedded Studios.
- `project-structure.md`: monorepo (no workspace tooling required) is now the recommended structure with a frontend; embedded Studio demoted to a legacy note.
- `get-started.md`: Studio creation now uses `--output-path studio` from the repo root with an explicit warning not to run the CLI inside a Next.js app (it switches to the embedded flow); the Next.js scaffold lands in `web/` alongside it.
- `typegen.md`, `visual-editing.md`, `SKILL.md`: monorepo TypeGen config is the primary example, the Presentation `previewUrl` snippet gains the `origin` required for standalone Studios, and quick-reference descriptions drop embedded Studio.

## Test plan

- [x] Review rendered markdown for the six touched files
- [x] Sanity-check the standalone Studio CLI command (`npm create sanity@latest -- ... --output-path studio`) against the current CLI behavior
- [x] Confirm the onboarding agent prompt ("getting-started reference") now produces a standalone `studio/` + `web/` layout when followed end-to-end

Made with [Cursor](https://cursor.com)