### PR TITLE
feat: update references to MCP server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a Sanity-powered project. Use the Knowledge Router below to find Sanity 
 npx sanity@latest mcp configure  # Configure MCP for your AI editor
 
 # Schema & Types
-npx sanity schema deploy     # Deploy schema to Content Lake (REQUIRED before MCP!)
+npx sanity schema deploy     # Deploy schema to Content Lake for MCP/editor access
 npx sanity schema extract    # Extract schema for TypeGen
 npx sanity typegen generate  # Generate TypeScript types
 
@@ -84,10 +84,8 @@ Example: If asked to "create a blog post schema", read `skills/sanity-best-pract
 |------|---------|
 | `query_documents` | Run GROQ queries |
 | `get_document` | Fetch a single document by exact ID |
-| `create_documents_from_json` | Create draft documents from JSON |
-| `create_documents_from_markdown` | Create draft documents from markdown |
-| `patch_document_from_json` | Apply precise modifications to document fields |
-| `patch_document_from_markdown` | Patch a field using markdown content |
+| `create_documents` | Create draft documents from structured content, or version documents when a release ID is provided |
+| `edit_document` | Apply precise modifications to document fields; published documents are edited by creating/updating a draft |
 | `publish_documents` | Publish one or more drafts |
 | `unpublish_documents` | Unpublish documents (move back to drafts) |
 | `discard_drafts` | Discard drafts while keeping published documents |
@@ -96,12 +94,13 @@ Example: If asked to "create a blog post schema", read `skills/sanity-best-pract
 
 | Tool | Use For |
 |------|---------|
-| `get_schema` | Get full schema of the current workspace |
+| `get_schema` | Get full schema of the current workspace (MCP-managed first, then Studio-deployed, then legacy schema) |
 | `list_workspace_schemas` | List all available workspace schema names |
-| `deploy_schema` | Deploy schema types to the cloud |
+| `deploy_schema` | Deploy MCP-managed schema types to the cloud |
+| `deploy_studio` | Deploy a hosted Studio bound to an MCP-managed schema |
 | `search_docs` / `read_docs` | Search and read Sanity documentation |
 | `list_sanity_rules` / `get_sanity_rules` | Load best-practice development rules |
-| `migration_guide` | Get guides for migrating from other CMSs |
+| `give_feedback` | Report MCP tool errors, missing capabilities, confusing output, or documentation issues |
 
 **Media & AI:**
 
@@ -114,6 +113,8 @@ Example: If asked to "create a blog post schema", read `skills/sanity-best-pract
 
 | Tool | Use For |
 |------|---------|
+| `create_release` | Create a release for coordinated content changes |
+| `list_releases` | List active, scheduled, published, or archived releases |
 | `create_version` | Create a version document for a release |
 | `version_replace_document` | Replace version contents from another document |
 | `version_discard` | Discard document versions from a release |
@@ -123,19 +124,21 @@ Example: If asked to "create a blog post schema", read `skills/sanity-best-pract
 
 | Tool | Use For |
 |------|---------|
+| `whoami` | Verify the authenticated Sanity user |
 | `list_projects` / `list_organizations` | List projects and organizations |
+| `get_project_studios` | List Studio applications linked to a project |
 | `create_project` | Create a new Sanity project |
 | `list_datasets` / `create_dataset` / `update_dataset` | Manage datasets |
 | `add_cors_origin` | Add CORS origins for client-side requests |
 | `list_embeddings_indices` / `semantic_search` | Semantic search on embeddings |
 
-**Critical:** After schema changes, deploy with `deploy_schema` before using content tools.
+**Critical:** After schema changes, deploy with `deploy_schema` so content tools see the latest schema. If using an MCP-managed Studio, redeploy it with `deploy_studio` after schema changes.
 
 ## Boundaries
 - **Always:**
   - Use `defineQuery` for all GROQ queries.
   - Prefer MCP tools for content operations (query, create, update, patch). For bulk migrations or when MCP is unavailable, NDJSON scripts are a valid alternative. Never use NDJSON scripts when MCP tools can accomplish the same task more simply.
-  - Run `deploy_schema` after schema changes — required before using content tools. If a local Studio exists, update schema files first to keep them in sync with the deployed schema.
+  - Run `deploy_schema` after schema changes so MCP content tools use the latest schema. If a local Studio exists, update schema files first to keep them in sync with the deployed schema. If using an MCP-managed Studio, run `deploy_studio` after `deploy_schema`.
   - Follow the "Deprecation Pattern" when removing fields (ReadOnly -> Hidden -> Deprecated).
   - Run `npm run typegen` after schema or query changes (or enable automatic generation with `typegen.enabled: true` in `sanity.cli.ts`).
 - **Ask First:**

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <h1 align="center">Sanity Agent Toolkit</h1>
 </p>
 
-Collection of resources to help AI agents build better with [Sanity](https://www.sanity.io). Supports Cursor, Claude Code, Codex, VS Code, Lovable, v0, and any other editor/agent compatible with MCP or [Agent Skills](https://agentskills.io).
+Collection of resources to help AI agents build better with [Sanity](https://www.sanity.io). Supports Cursor, Claude Code, Codex, VS Code, Lovable, v0, Replit, OpenCode, and any other editor/agent compatible with MCP or [Agent Skills](https://agentskills.io).
 
 ---
 
@@ -23,7 +23,7 @@ Collection of resources to help AI agents build better with [Sanity](https://www
 
 Choose your path based on how you want agents to work with Sanity:
 
-1. **MCP server** — Give your agent always up-to-date rules and full access to your Sanity projects. No local files to maintain. Works with Cursor, VS Code, Claude Code, Lovable, v0, and other MCP-compatible clients.
+1. **MCP server** — Give your agent always up-to-date rules and full access to your Sanity projects. No local files to maintain. Works with Cursor, VS Code, Claude Code, Lovable, v0, Replit, OpenCode, and other MCP-compatible clients.
 2. **Agent skills** — Install best practices skills for Sanity, content modeling, SEO/AEO, and experimentation. Works with Cursor, Claude Code, and any [Agent Skills](https://agentskills.io)-compatible agent.
 3. **Plugin** — Install the Sanity plugin for Cursor or Claude Code. Bundles MCP server, agent skills, and commands.
 4. **Manual installation** — Copy the skill references locally for offline use. You'll need to update them yourself.
@@ -168,7 +168,11 @@ If your client doesn't support remote MCP servers, use a proxy like `mcp-remote`
 
 <br />
 
-See the [Sanity MCP docs](https://www.sanity.io/docs/compute-and-ai/mcp-server) for authorization options and troubleshooting.
+#### Authorization and troubleshooting
+
+Manual MCP configuration uses OAuth by default. You can use token auth instead by setting an `Authorization: Bearer <token>` header in the MCP config. If authentication fails after CLI setup, rerun `npx sanity@latest mcp configure` and restart your MCP client. For OAuth reset issues, Cursor provides **Cursor: Clear All MCP Tokens** and VS Code provides **Authentication: Remove Dynamic Authentication Providers**.
+
+See the [Sanity MCP docs](https://www.sanity.io/docs/ai/mcp-server) for authorization options and troubleshooting.
 
 ### Option 2: Install Agent Skills
 
@@ -270,16 +274,23 @@ Install the skill references locally to teach your editor Sanity best practices:
 
 With MCP connected, your AI can use tools like:
 - `query_documents` — run GROQ queries directly
-- `create_documents_from_json` / `create_documents_from_markdown` — create draft documents
-- `patch_document_from_json` / `patch_document_from_markdown` — surgical edits to existing documents
+- `create_documents` — create draft documents from structured content, or version documents when a release ID is provided
+- `edit_document` — surgical edits to existing documents; published documents are edited by creating or updating drafts
 - `publish_documents` / `unpublish_documents` — manage document lifecycle
-- `deploy_schema` / `get_schema` — deploy and inspect schemas
+- `deploy_schema` / `get_schema` — deploy MCP-managed schemas and inspect deployed schemas
+- `deploy_studio` — deploy a hosted Studio bound to an MCP-managed schema
+- `create_release` / `list_releases` — create and inspect Content Releases
 - `create_version` — create version documents for releases
 - `generate_image` / `transform_image` — AI image generation and editing
+- `whoami` — verify the authenticated Sanity user
+- `get_project_studios` — list Studio applications linked to a project
 - `search_docs` / `read_docs` — search and read Sanity documentation
 - `list_sanity_rules` / `get_sanity_rules` — load agent rules on demand
+- `give_feedback` — report MCP tool errors, missing capabilities, confusing output, or documentation issues
 
-See the [full list of available tools](https://www.sanity.io/docs/compute-and-ai/mcp-server#k4ae680bb2e88).
+MCP-managed schemas are resolved before Studio-deployed and legacy schemas. If you deploy schema changes with `deploy_schema`, redeploy any matching MCP-managed Studio with `deploy_studio` so it picks up the latest schema. `generate_image`, `transform_image`, and `create_version` with an `instruction` consume Sanity AI credits.
+
+See the [full list of available tools](https://www.sanity.io/docs/ai/mcp-server#available-tools).
 
 ### Agent skills
 
@@ -366,7 +377,7 @@ All skills use `references/` for detailed content loaded on demand. The `sanity-
 - [GROQ language reference](https://www.sanity.io/docs/groq)
 - [Visual Editing guide](https://www.sanity.io/docs/visual-editing)
 - [Sanity TypeGen](https://www.sanity.io/docs/sanity-typegen)
-- [MCP server docs](https://www.sanity.io/docs/compute-and-ai/mcp-server)
+- [MCP server docs](https://www.sanity.io/docs/ai/mcp-server)
 - [Blueprints Infrastructure as Code](https://www.sanity.io/docs/compute-and-ai/blueprints)
 
 ---

--- a/commands/deploy-schema.md
+++ b/commands/deploy-schema.md
@@ -10,7 +10,7 @@ I'll help you deploy your schema to the Sanity Content Lake.
 ## Why Deploy Schema?
 
 Schema deployment is **required** for:
-- ⚠️ **MCP Server operations** (create_document, patch_document)
+- ⚠️ **MCP Server content operations** (`create_documents`, `edit_document`) to use the latest schema
 - Embedded Studios
 - Scheduled Publishing
 - Cloud Functions with schema validation
@@ -43,14 +43,14 @@ npx sanity schema deploy
 | Added new document type | ✅ Yes |
 | Added/modified fields | ✅ Yes |
 | Changed validation rules | ✅ Yes |
-| Using MCP tools | ✅ Yes (always) |
+| Using MCP content tools after schema changes | ✅ Yes |
 | Local dev only (no MCP) | Optional |
 
 ## Important Notes
 
 - **Schema deployment is fast** (~2 seconds)
 - **Does NOT deploy the Studio app** (use `npx sanity deploy` for that)
-- **Always deploy before MCP operations** after schema changes
+- **Always deploy before MCP content operations** after schema changes
 
 ## Usage
 

--- a/commands/sanity.md
+++ b/commands/sanity.md
@@ -21,7 +21,7 @@ I can help you build with Sanity. Here are the core skills and help areas availa
 - Plan content models and experimentation workflows
 
 **Content operations**
-- I can also access the **Sanity MCP Server** directly to query data, create documents, patch content, inspect schemas, and manage datasets.
+- I can also access the **Sanity MCP Server** directly to query data, create and edit documents, inspect schemas, and manage datasets.
 
 **How to start?**
 Just ask me naturally! For example:

--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -125,19 +125,18 @@ This uploads your schema to the Content Lake so MCP tools can work with it.
 ### Step 2a: Import Existing Content
 
 If migrating from another CMS or files:
-- See `migration.md`
-- Use MCP `migrate_content` tool for guidance
+- See `migration.md` and the `sanity-migration` skill for guidance
+- Use MCP content tools such as `create_documents` and `edit_document` after converting content to structured Sanity documents
 
 ### Step 2b: Generate Sample Content (MCP)
 
-Use the Sanity MCP Server:
+Ask the agent to draft structured sample content, then create it with the Sanity MCP Server:
 ```
-Tool: create_document
-Type: post
-Content: Create a sample blog post about getting started with Sanity
+Tool: create_documents
+Documents: [{ type: "post", content: { title: "Getting started with Sanity", body: [] } }]
 ```
 
-**If MCP fails:** Remind them to run `npx sanity schema deploy` first.
+**If MCP content tools cannot see new types or fields:** Remind them to run `npx sanity schema deploy` first.
 
 ### MCP Setup (If Not Configured)
 
@@ -380,7 +379,7 @@ Just ask about any of these!"
 ```bash
 npx sanity@latest mcp configure  # Configure MCP for your editor
 npx sanity dev                   # Start Studio locally
-npx sanity schema deploy         # Deploy schema (required for MCP!)
+npx sanity schema deploy         # Deploy schema for MCP/editor access
 npx sanity deploy                # Deploy Studio to Sanity hosting
 npx sanity manage                # Open project settings
 npm run typegen                  # Generate TypeScript types
@@ -393,5 +392,5 @@ npm run typegen                  # Generate TypeScript types
 - **Be succinct** — Guide step-by-step without over-explaining
 - **Check context first** — Read existing files before suggesting changes
 - **Don't give up** — If something fails, give the user a way to complete manually
-- **Deploy schema early** — MCP tools won't work without it
+- **Deploy schema early** — MCP content tools need deployed schemas to see new types and fields
 - **One phase at a time** — Complete each phase before moving to the next


### PR DESCRIPTION
Updates references to the Sanity MCP server + a few minor changes

- Use the new migration skill, remove references to the deleted `migration_guide` tool
- Update list of available tools + params
- Loosen schema deployment guidelines, to better reflect the current MCP behavior when schemas are (or aren't) deployed