### PR TITLE
fix: correct buggy example code in skills, standardize CLI command form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ This is a Sanity-powered project. Use the Knowledge Router below to find Sanity 
 npx sanity@latest mcp configure  # Configure MCP for your AI editor
 
 # Schema & Types
-npx sanity schema deploy     # Deploy schema to Content Lake for MCP/editor access
-npx sanity schema extract    # Extract schema for TypeGen
+npx sanity schemas deploy     # Deploy schema to Content Lake for MCP/editor access
+npx sanity schemas extract    # Extract schema for TypeGen
 npx sanity typegen generate  # Generate TypeScript types
 
 # Development

--- a/commands/deploy-schema.md
+++ b/commands/deploy-schema.md
@@ -18,7 +18,7 @@ Schema deployment is **required** for:
 ## Deployment Command
 
 ```bash
-npx sanity schema deploy
+npx sanity schemas deploy
 ```
 
 ## What I'll Do
@@ -29,7 +29,7 @@ npx sanity schema deploy
    - Warn about removed fields with data
 
 2. **Deploy**
-   - Run `npx sanity schema deploy`
+   - Run `npx sanity schemas deploy`
    - Confirm success
 
 3. **Post-Deploy Verification**

--- a/commands/typegen.md
+++ b/commands/typegen.md
@@ -12,7 +12,7 @@ I'll help you generate TypeScript types from your Sanity schema.
 ```bash
 npm run typegen
 # or
-npx sanity schema extract && npx sanity typegen generate
+npx sanity schemas extract && npx sanity typegen generate
 ```
 
 ## What I'll Do

--- a/skills/content-experimentation-best-practices/references/cms-integration.md
+++ b/skills/content-experimentation-best-practices/references/cms-integration.md
@@ -149,6 +149,11 @@ function assignVariant(experimentId: string, variants: Variant[]): string | null
   // splits work even when weights don't sum to 100 (otherwise draws above the
   // sum skew to the fallback).
   const totalWeight = variants.reduce((sum, v) => sum + v.weight, 0)
+  if (totalWeight <= 0) {
+    const fallback = variants[0]
+    setCookie(cookieKey, fallback.id, { maxAge: 30 * 24 * 60 * 60 })
+    return fallback.id
+  }
   const rand = Math.random() * totalWeight
   let cumulative = 0
   for (const variant of variants) {

--- a/skills/content-experimentation-best-practices/references/cms-integration.md
+++ b/skills/content-experimentation-best-practices/references/cms-integration.md
@@ -133,33 +133,52 @@ defineField({
 ### 3. Frontend Assignment
 
 ```typescript
-// Middleware or server-side
-function assignVariant(experimentId: string, variants: Variant[]): string {
-  // Check for existing assignment in cookie
+// Middleware or server-side. Returns the assigned variant id, or null when the
+// experiment has no variants to assign.
+function assignVariant(experimentId: string, variants: Variant[]): string | null {
+  if (variants.length === 0) return null
+
+  // Reuse an existing assignment, but only if it's still a valid variant.
+  // After variants are renamed or removed, drop the stale cookie and reassign,
+  // otherwise users stay bucketed to IDs that no longer exist.
   const cookieKey = `exp_${experimentId}`
   const existing = getCookie(cookieKey)
-  if (existing) return existing
-  
-  // Random assignment based on weights
-  const rand = Math.random() * 100
+  if (existing && variants.some(v => v.id === existing)) return existing
+
+  // Random assignment based on weights. Normalize against the total weight so
+  // splits work even when weights don't sum to 100 (otherwise draws above the
+  // sum skew to the fallback).
+  const totalWeight = variants.reduce((sum, v) => sum + v.weight, 0)
+  const rand = Math.random() * totalWeight
   let cumulative = 0
   for (const variant of variants) {
     cumulative += variant.weight
-    if (rand <= cumulative) {
+    if (rand < cumulative) {
       setCookie(cookieKey, variant.id, { maxAge: 30 * 24 * 60 * 60 })
       return variant.id
     }
   }
-  return variants[0].id
+  // Fall back to the last variant to absorb any floating-point remainder.
+  return variants[variants.length - 1].id
 }
 ```
 
 ### 4. Query with Variant
 
+Resolve **one** experiment's assignment at a time, passing both its
+`experimentId` and the `variantId` returned by `assignVariant`. Match on both:
+variant IDs like `control` repeat across experiments, so filtering on
+`variantId` alone could pick a different running experiment's row. For a page
+running several experiments, resolve each one separately and merge the results.
+
 ```groq
 *[_type == "page" && slug.current == $slug][0]{
   ...,
-  "experiment": experimentVariants[experimentId->status == "running"][0]{
+  "experiment": experimentVariants[
+    experimentId->_id == $experimentId &&
+    experimentId->status == "running" &&
+    variantId == $variantId
+  ][0]{
     experimentId->{name, _id},
     variantId,
     headline

--- a/skills/content-experimentation-best-practices/references/cms-integration.md
+++ b/skills/content-experimentation-best-practices/references/cms-integration.md
@@ -158,8 +158,11 @@ function assignVariant(experimentId: string, variants: Variant[]): string | null
       return variant.id
     }
   }
-  // Fall back to the last variant to absorb any floating-point remainder.
-  return variants[variants.length - 1].id
+  // Fall back to the last variant to absorb any floating-point remainder, and
+  // persist it like any other assignment so the visitor stays bucketed.
+  const fallback = variants[variants.length - 1]
+  setCookie(cookieKey, fallback.id, { maxAge: 30 * 24 * 60 * 60 })
+  return fallback.id
 }
 ```
 

--- a/skills/portable-text-conversion/rules/html-to-pt.md
+++ b/skills/portable-text-conversion/rules/html-to-pt.md
@@ -124,7 +124,9 @@ const blocks = htmlToBlocks(html, blockContentType, {
             _ref: '', // Upload image separately, set ref after
           },
           alt: el.getAttribute('alt') || '',
-          _sanityAsset: `image@${src}`, // for migration tooling
+          // Resolved by `sanity dataset import` only. On client/mutation-API
+          // write paths, upload the asset first and set `asset._ref` instead.
+          _sanityAsset: `image@${src}`,
         })
       },
     },

--- a/skills/portable-text-conversion/rules/html-to-pt.md
+++ b/skills/portable-text-conversion/rules/html-to-pt.md
@@ -114,6 +114,9 @@ const blocks = htmlToBlocks(html, blockContentType, {
       deserialize(el, next, block) {
         if (el.tagName?.toLowerCase() !== 'img') return undefined
 
+        const src = el.getAttribute('src')
+        if (!src) return undefined // skip sourceless images, not `image@null`
+
         return block({
           _type: 'image',
           asset: {
@@ -121,7 +124,7 @@ const blocks = htmlToBlocks(html, blockContentType, {
             _ref: '', // Upload image separately, set ref after
           },
           alt: el.getAttribute('alt') || '',
-          _sanityAsset: `image@${el.getAttribute('src')}`, // for migration tooling
+          _sanityAsset: `image@${src}`, // for migration tooling
         })
       },
     },

--- a/skills/portable-text-conversion/rules/html-to-pt.md
+++ b/skills/portable-text-conversion/rules/html-to-pt.md
@@ -124,7 +124,7 @@ const blocks = htmlToBlocks(html, blockContentType, {
             _ref: '', // Upload image separately, set ref after
           },
           alt: el.getAttribute('alt') || '',
-          // Resolved by `sanity dataset import` only. On client/mutation-API
+          // Resolved by `sanity datasets import` only. On client/mutation-API
           // write paths, upload the asset first and set `asset._ref` instead.
           _sanityAsset: `image@${src}`,
         })
@@ -238,7 +238,7 @@ export default defineMigration({
 })
 ```
 
-Run with: `sanity migration run import-wordpress-posts --no-dry-run`
+Run with: `sanity migrations run import-wordpress-posts --no-dry-run`
 
 ## Reference
 

--- a/skills/sanity-best-practices/references/angular.md
+++ b/skills/sanity-best-practices/references/angular.md
@@ -458,7 +458,9 @@ export class SanityService {
   private platformId = inject(PLATFORM_ID)
 
   async fetch<Query extends string>(query: Query, params?: QueryParams): Promise<ClientReturn<Query>> {
-    const key = makeStateKey<ClientReturn<Query>>(await hashQuery(query, params))
+    // The key type includes `null` so `get(key, null)` type-checks against
+    // Angular's `get<T>(key: StateKey<T>, defaultValue: T): T` signature.
+    const key = makeStateKey<ClientReturn<Query> | null>(await hashQuery(query, params))
 
     if (isPlatformBrowser(this.platformId)) {
       const cached = this.transferState.get(key, null)

--- a/skills/sanity-best-practices/references/angular.md
+++ b/skills/sanity-best-practices/references/angular.md
@@ -442,39 +442,38 @@ Key considerations for Sanity + Angular SSR:
 Angular's built-in HTTP Transfer Cache does not cover `@sanity/client` requests. Without manual transfer, the client re-fetches every query during hydration. Add `TransferState` to the service from Section 2:
 
 ```typescript
-+ async function hashQuery(query: string, params?: QueryParams): Promise<string> {
-+   const input = query + JSON.stringify(params ?? {})
-+   const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input))
-+   return Array.from(new Uint8Array(buffer), b => b.toString(16).padStart(2, '0')).join('')
-+ }
-
-import { Injectable, inject } from '@angular/core'
-+ import { isPlatformBrowser, isPlatformServer } from '@angular/common'
-+ import { PLATFORM_ID, makeStateKey, TransferState } from '@angular/core'
+import { Injectable, inject, PLATFORM_ID, makeStateKey, TransferState } from '@angular/core'
+import { isPlatformBrowser, isPlatformServer } from '@angular/common'
 import { createClient, type ClientReturn, type QueryParams, type SanityClient } from '@sanity/client'
+
+async function hashQuery(query: string, params?: QueryParams): Promise<string> {
+  const input = query + JSON.stringify(params ?? {})
+  const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input))
+  return Array.from(new Uint8Array(buffer), b => b.toString(16).padStart(2, '0')).join('')
+}
 
 export class SanityService {
   private client: SanityClient
-+  private transferState = inject(TransferState)
-+  private platformId = inject(PLATFORM_ID)
+  private transferState = inject(TransferState)
+  private platformId = inject(PLATFORM_ID)
 
   async fetch<Query extends string>(query: Query, params?: QueryParams): Promise<ClientReturn<Query>> {
-+    const key = makeStateKey<ClientReturn<Query>>(await hashQuery(query, params))
-+
-+    if (isPlatformBrowser(this.platformId)) {
-+      const cached = this.transferState.get(key, null)
-+      if (cached !== null) {
-+        this.transferState.remove(key)
-+        return cached
-+      }
-+    }
-+
+    const key = makeStateKey<ClientReturn<Query>>(await hashQuery(query, params))
+
+    if (isPlatformBrowser(this.platformId)) {
+      const cached = this.transferState.get(key, null)
+      if (cached !== null) {
+        this.transferState.remove(key)
+        return cached
+      }
+    }
+
     const result = await this.client.fetch(query, params)
-+
-+    if (isPlatformServer(this.platformId)) {
-+      this.transferState.set(key, result)
-+    }
-+
+
+    if (isPlatformServer(this.platformId)) {
+      this.transferState.set(key, result)
+    }
+
     return result
   }
 }

--- a/skills/sanity-best-practices/references/functions.md
+++ b/skills/sanity-best-practices/references/functions.md
@@ -461,7 +461,10 @@ defineDocumentFunction({
   name: 'auto-tag',
   event: {
     on: ['create', 'update'],
-    filter: "_type == 'post'",
+    // Only fire while tags are missing. The handler writes to `tags`, which
+    // emits another `update` event — without this guard the function would
+    // re-trigger itself in a loop. Once tags exist, the filter stops matching.
+    filter: "_type == 'post' && !defined(tags)",
     projection: '{_id, title, body}',
   },
 })

--- a/skills/sanity-best-practices/references/functions.md
+++ b/skills/sanity-best-practices/references/functions.md
@@ -94,7 +94,10 @@ export default defineBlueprint({
       name: 'my-function',
       event: {
         on: ['create', 'update'],
-        filter: '_type == "post"',
+        // The handler patches the same document, which emits another update
+        // event. Guard with !defined(firstPublished) so the function stops
+        // matching once it has run — see "Recursion control" below.
+        filter: '_type == "post" && !defined(firstPublished)',
       },
     }),
   ],

--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -97,7 +97,7 @@ export const post = defineType({
 **Required before Phase 2:**
 
 ```bash
-npx sanity schema deploy
+npx sanity schemas deploy
 ```
 
 This uploads your schema to the Content Lake so MCP tools can work with it.
@@ -137,7 +137,7 @@ Tool: create_documents
 Documents: [{ type: "post", content: { title: "Getting started with Sanity", body: [] } }]
 ```
 
-**If MCP content tools cannot see new types or fields:** Remind them to run `npx sanity schema deploy` first.
+**If MCP content tools cannot see new types or fields:** Remind them to run `npx sanity schemas deploy` first.
 
 ### MCP Setup (If Not Configured)
 
@@ -385,7 +385,7 @@ Just ask about any of these!"
 ```bash
 npx sanity@latest mcp configure  # Configure MCP for your editor
 npx sanity dev                   # Start Studio locally
-npx sanity schema deploy         # Deploy schema for MCP/editor access
+npx sanity schemas deploy         # Deploy schema for MCP/editor access
 npx sanity deploy                # Deploy Studio to Sanity hosting
 npx sanity manage                # Open project settings
 npm run typegen                  # Generate TypeScript types

--- a/skills/sanity-best-practices/references/migration-html-import.md
+++ b/skills/sanity-best-practices/references/migration-html-import.md
@@ -59,11 +59,11 @@ const blocks = htmlToBlocks(htmlString, blockContentType, {
         if (el.tagName?.toLowerCase() === 'img') {
           const src = el.getAttribute('src')
           // Skip sourceless images rather than emitting `image@null`, which
-          // fails later at asset-upload time with no pointer to the bad node.
+          // the importer reports as a failed asset with no pointer to the node.
           if (!src) return undefined
           return block({
             _type: 'image',
-            // Upload image separately, store reference
+            // NDJSON + `sanity dataset import` only — see the note below.
             _sanityAsset: `image@${src}`
           })
         }
@@ -73,6 +73,14 @@ const blocks = htmlToBlocks(htmlString, blockContentType, {
   ]
 })
 ```
+
+> **`_sanityAsset` is only resolved by `sanity dataset import`.** The NDJSON
+> importer fetches each `image@<url>` and swaps in a real asset reference. The
+> mutation API does not interpret the directive, so the same blocks written
+> through `@sanity/client`, `sanity exec`, or `defineMigration` are stored
+> verbatim — leaving an image field with a stray `_sanityAsset` string and no
+> `asset` reference. On those paths, upload the image first and emit an asset
+> reference instead, as in [Image Upload](#image-upload) below.
 
 ### Pre-Processing HTML
 
@@ -119,7 +127,9 @@ async function uploadImage(client, imageUrl) {
 
 ### Using in a Migration
 
-Wrap this in `defineMigration` for controlled imports:
+Wrap this in `defineMigration` for controlled imports. This path writes through
+the mutation API, so any custom rules used here must emit uploaded asset
+references rather than `_sanityAsset` directives:
 
 ```typescript
 // migrations/import-wordpress-posts/index.ts

--- a/skills/sanity-best-practices/references/migration-html-import.md
+++ b/skills/sanity-best-practices/references/migration-html-import.md
@@ -37,21 +37,27 @@ const blocks = htmlToBlocks(htmlString, blockContentType, {
   rules: [
     {
       deserialize(el, next, block) {
-        // Custom link handling
+        // Custom link handling — links are inline annotations, not blocks.
+        // Return an `__annotation` with a `markDef`, and recurse into the
+        // child nodes via `next()` so the link text is preserved.
         if (el.tagName.toLowerCase() === 'a') {
           return {
-            _type: 'link',
-            href: el.getAttribute('href'),
-            blank: el.getAttribute('target') === '_blank'
+            _type: '__annotation',
+            markDef: {
+              _type: 'link',
+              href: el.getAttribute('href'),
+              blank: el.getAttribute('target') === '_blank'
+            },
+            children: next(el.childNodes)
           }
         }
-        // Custom image handling
+        // Custom image handling — block-level types are wrapped with `block()`
         if (el.tagName.toLowerCase() === 'img') {
-          return {
+          return block({
             _type: 'image',
             // Upload image separately, store reference
             _sanityAsset: `image@${el.getAttribute('src')}`
-          }
+          })
         }
         return undefined  // Fall through to default handling
       }

--- a/skills/sanity-best-practices/references/migration-html-import.md
+++ b/skills/sanity-best-practices/references/migration-html-import.md
@@ -40,7 +40,7 @@ const blocks = htmlToBlocks(htmlString, blockContentType, {
         // Custom link handling — links are inline annotations, not blocks.
         // Return an `__annotation` with a `markDef`, and recurse into the
         // child nodes via `next()` so the link text is preserved.
-        if (el.tagName.toLowerCase() === 'a') {
+        if (el.tagName?.toLowerCase() === 'a') {
           return {
             _type: '__annotation',
             markDef: {
@@ -52,7 +52,7 @@ const blocks = htmlToBlocks(htmlString, blockContentType, {
           }
         }
         // Custom image handling — block-level types are wrapped with `block()`
-        if (el.tagName.toLowerCase() === 'img') {
+        if (el.tagName?.toLowerCase() === 'img') {
           return block({
             _type: 'image',
             // Upload image separately, store reference

--- a/skills/sanity-best-practices/references/migration-html-import.md
+++ b/skills/sanity-best-practices/references/migration-html-import.md
@@ -63,7 +63,7 @@ const blocks = htmlToBlocks(htmlString, blockContentType, {
           if (!src) return undefined
           return block({
             _type: 'image',
-            // NDJSON + `sanity dataset import` only — see the note below.
+            // NDJSON + `sanity datasets import` only — see the note below.
             _sanityAsset: `image@${src}`
           })
         }
@@ -74,7 +74,7 @@ const blocks = htmlToBlocks(htmlString, blockContentType, {
 })
 ```
 
-> **`_sanityAsset` is only resolved by `sanity dataset import`.** The NDJSON
+> **`_sanityAsset` is only resolved by `sanity datasets import`.** The NDJSON
 > importer fetches each `image@<url>` and swaps in a real asset reference. The
 > mutation API does not interpret the directive, so the same blocks written
 > through `@sanity/client`, `sanity exec`, or `defineMigration` are stored
@@ -160,6 +160,6 @@ export default defineMigration({
 
 Let Sanity generate document IDs for ordinary imported content. Add schema fields for legacy identifiers or slugs, then use GROQ lookups against those fields when you need to rerun an import, patch existing documents, or create references between imported records. Set `_id` directly only for singleton documents.
 
-Run with: `sanity migration run import-wordpress-posts --no-dry-run`
+Run with: `sanity migrations run import-wordpress-posts --no-dry-run`
 
 Reference: [Schema and Content Migrations](https://www.sanity.io/docs/content-lake/schema-and-content-migrations)

--- a/skills/sanity-best-practices/references/migration-html-import.md
+++ b/skills/sanity-best-practices/references/migration-html-import.md
@@ -41,11 +41,15 @@ const blocks = htmlToBlocks(htmlString, blockContentType, {
         // Return an `__annotation` with a `markDef`, and recurse into the
         // child nodes via `next()` so the link text is preserved.
         if (el.tagName?.toLowerCase() === 'a') {
+          const href = el.getAttribute('href')
+          // An anchor with no `href` (named anchors, JS-driven links) isn't a
+          // link. Fall through so the text survives without a dangling markDef.
+          if (!href) return undefined
           return {
             _type: '__annotation',
             markDef: {
               _type: 'link',
-              href: el.getAttribute('href'),
+              href,
               blank: el.getAttribute('target') === '_blank'
             },
             children: next(el.childNodes)
@@ -53,10 +57,14 @@ const blocks = htmlToBlocks(htmlString, blockContentType, {
         }
         // Custom image handling — block-level types are wrapped with `block()`
         if (el.tagName?.toLowerCase() === 'img') {
+          const src = el.getAttribute('src')
+          // Skip sourceless images rather than emitting `image@null`, which
+          // fails later at asset-upload time with no pointer to the bad node.
+          if (!src) return undefined
           return block({
             _type: 'image',
             // Upload image separately, store reference
-            _sanityAsset: `image@${el.getAttribute('src')}`
+            _sanityAsset: `image@${src}`
           })
         }
         return undefined  // Fall through to default handling

--- a/skills/sanity-best-practices/references/schema.md
+++ b/skills/sanity-best-practices/references/schema.md
@@ -313,10 +313,10 @@ export default defineMigration({
 
 ```bash
 # Dry run first (default)
-sanity migration run rename-oldTitle-to-newTitle
+sanity migrations run rename-oldTitle-to-newTitle
 
 # Execute when ready
-sanity migration run rename-oldTitle-to-newTitle --no-dry-run
+sanity migrations run rename-oldTitle-to-newTitle --no-dry-run
 ```
 
 **Phase 3: Remove** — Once `oldTitle` is undefined for all documents, delete the field definition.

--- a/skills/sanity-best-practices/references/typegen.md
+++ b/skills/sanity-best-practices/references/typegen.md
@@ -29,7 +29,7 @@ Run the extract + generate cycle whenever schema or queries change:
 2.  **Generate:** Scans your codebase for GROQ queries and generates TypeScript types.
 
 ```bash
-npx sanity schema extract && npx sanity typegen generate
+npx sanity schemas extract && npx sanity typegen generate
 ```
 
 ### Watch Mode (for separate frontends)
@@ -45,7 +45,7 @@ For manual workflows, implement a single script:
 **package.json:**
 ```json
 "scripts": {
-  "typegen": "sanity schema extract && sanity typegen generate"
+  "typegen": "sanity schemas extract && sanity typegen generate"
 }
 ```
 
@@ -147,7 +147,7 @@ export default function Author({ data }: { data: AUTHOR_QUERYResult }) {
 Use `--enforce-required-fields` during extraction to translate `validation: rule => rule.required()` into non-optional types:
 
 ```bash
-npx sanity schema extract --enforce-required-fields
+npx sanity schemas extract --enforce-required-fields
 npx sanity typegen generate
 ```
 

--- a/skills/sanity-migration/SKILL.md
+++ b/skills/sanity-migration/SKILL.md
@@ -35,7 +35,7 @@ For implementation or planning tasks, produce these artifacts or explain why the
 ## Defaults
 
 - Use stable document IDs derived from source IDs, slugs, paths, or hashes.
-- Use `createOrReplace`, `createIfNotExists`, or `sanity dataset import --replace` so reruns converge.
+- Use `createOrReplace`, `createIfNotExists`, or `sanity datasets import --replace` so reruns converge.
 - Snapshot extracted source data to disk before transforming it.
 - Import or create referenced documents before documents that reference them.
 - Convert rich text to Portable Text instead of storing raw HTML or Markdown strings.

--- a/skills/sanity-migration/references/contentful.md
+++ b/skills/sanity-migration/references/contentful.md
@@ -49,7 +49,7 @@ Typical workflow:
 npm create sanity@latest -- --template clean --create-project "Migrated Contentful" --dataset production --output-path ./migrate
 npx contentful-to-sanity@latest -s <space-id> -t <management-token> -a <delivery-token> ./migrate
 cd ./migrate
-npx sanity dataset import ./dataset.ndjson production
+npx sanity datasets import ./dataset.ndjson production
 ```
 
 If the generated Studio imports schemas from `./schemas`, update it to use the generated schema export from `./schema` as instructed by the package output.

--- a/skills/sanity-migration/references/general.md
+++ b/skills/sanity-migration/references/general.md
@@ -113,7 +113,7 @@ Rich text is usually the long pole. Pick the converter by source format:
 
 Choose the write path by migration size and repeatability:
 
-- **NDJSON + `sanity dataset import`:** best for large initial loads and export-file migrations. Supports `_sanityAsset` directives and `--replace`.
+- **NDJSON + `sanity datasets import`:** best for large initial loads and export-file migrations. Supports `_sanityAsset` directives and `--replace`.
 - **`sanity migration`:** good for reproducible scripted imports inside a Studio project, dry runs, and batched mutations.
 - **`sanity exec` or custom scripts with `@sanity/client`:** good for custom extraction/import loops, incremental syncs, or complex asset upload flows.
 - **Sanity MCP/content tools:** good for small targeted operations, inspection, and patches. Avoid them for bulk content loads when a script or NDJSON import is more reliable.

--- a/skills/sanity-migration/references/markdown.md
+++ b/skills/sanity-migration/references/markdown.md
@@ -112,7 +112,7 @@ For bulk imports, prefer NDJSON:
 Then import with:
 
 ```bash
-npx sanity dataset import import.ndjson <dataset> --replace
+npx sanity datasets import import.ndjson <dataset> --replace
 ```
 
 Use client `createOrReplace` for smaller imports or incremental syncs.


### PR DESCRIPTION
## What

Two things, both aimed at snippets an agent loads the skill and copies verbatim:

1. Fixes buggy example code in five skill references.
2. Standardizes the Sanity CLI command form, which the repo was using inconsistently.

## 1. Example bug fixes

### `content-experimentation-best-practices/references/cms-integration.md`

`assignVariant` and the variant query had several issues:

- **Weights not normalized.** It drew `Math.random() * 100` but never normalized against the sum of `weight`s. When weights don't total 100, draws above the sum fall through to the fallback variant and skew the split — which the skill's own pitfalls section warns about.
- **Non-positive total weight.** With weights summing to 0, the loop never matches and every visitor lands on the fallback. Now guarded with a deterministic first-variant assignment.
- **Stale cookie never revalidated.** It returned any existing cookie value without checking the ID is still a valid variant, so after a variant is renamed or removed users stay bucketed to a dead ID.
- **Empty array crashes.** `variants[variants.length - 1].id` throws on an empty `variants` array. Now returns `null`.
- **Boundary off by one.** `rand <= cumulative` could select a zero-weight variant when the draw landed exactly on the boundary. Now `rand < cumulative`.
- **Fallback not persisted.** The floating-point remainder path returned a variant without setting the cookie, so the visitor got re-bucketed on the next request.
- **Query ignored the assignment.** The GROQ example filtered `experimentVariants` only by `experimentId->status == "running"` and took `[0]`, so the first running experiment always won regardless of the user's assigned variant. Now scoped by `experimentId` **and** the assigned `variantId` (variant IDs like `control` repeat across experiments, so matching `variantId` alone is ambiguous), with a note to resolve one experiment at a time.

### `sanity-best-practices/references/migration-html-import.md`

The custom `<a>` deserializer returned a top-level `{ _type: 'link' }` block. `htmlToBlocks` expects link markup as an `__annotation` with a `markDef` and `children` from `next()` — the pattern already documented in `portable-text-conversion/rules/html-to-pt.md`. Aligned the link rule (and wrapped the image rule in `block()`) to match.

Both rules also assumed the attribute they read is present. `getAttribute` returns `null` when it isn't, so the examples could emit `href: null` markDefs and the literal string `image@null`. They now read the attribute once and fall through when it's absent, leaving the surrounding text to default handling.

### `sanity-best-practices/references/functions.md`

The `auto-tag` function listened on `create`/`update` for all posts and wrote to `tags` via Agent Actions with no guard. Each tag write emits another `update`, so the function re-triggers itself in a loop. Added `&& !defined(tags)` to the event filter, mirroring the recursion guard the translation example just above it already uses. Same guard applied to the `firstPublished` example earlier in the file.

### `sanity-best-practices/references/angular.md`

The `TransferState` snippet had leftover `+` diff markers in the code block and declared `hashQuery` above the imports. Cleaned up to a copyable file.

The key was also mistyped: `makeStateKey<ClientReturn<Query>>` followed by `transferState.get(key, null)` doesn't type-check against Angular's `get<T>(key: StateKey<T>, defaultValue: T): T`. The key type now includes `null`.

## 2. `_sanityAsset` scoped to the NDJSON import path

`_sanityAsset` is resolved by the CLI importer, which fetches each `image@<url>` and swaps in a real asset reference. The mutation API does not interpret it, so the same blocks written through `@sanity/client`, `sanity exec`, or `defineMigration` are stored verbatim, leaving an image field with no `asset` reference.

Neither example said so. `migration-html-import.md` labelled the directive `// Upload image separately, store reference` — a description of the client-upload path it is *not* — and then went on to demonstrate `defineMigration`, the very path where the directive is inert. Both call sites now name the supported path, with a note pointing at the upload-first alternative and a caution in the `defineMigration` section.

Ref: [Importing data](https://www.sanity.io/docs/content-lake/importing-data)

## 3. Plural CLI topics

The repo used both forms: `sanity dataset import` / `schema deploy` / `migration run` alongside `blueprints *` / `functions *`. Standardized on plural (22 occurrences across 12 files).

Plural is the canonical topic in `@sanity/cli` 7.x — registered in `oclif.config.js` and backed by `dist/commands/<topic>/`, so oclif dispatches it directly. Singular resolves only by missing oclif lookup and landing in the `command_not_found` hook, which rewrites it via `topicAliases`. That shim works today and is silent, but it's a compatibility path and not what the docs show.

**Worth knowing:** this makes the commands v7-only. On v3.x the singular form was canonical and the plural topics don't exist at all.

## Notes

- The original three fixes were surfaced by an automated review (Cursor Bugbot) on a downstream repo that vendors these skills. The rest came from Copilot review on this PR and from follow-up checks against the Sanity docs and the `@sanity/cli` 7.14.0 package.
- `npm run validate` passes for all skills.
- Docs/examples only — no behavioral change to the toolkit itself.
- Section 3 is a separable concern from the example fixes. Happy to split it into its own PR if you'd rather review them apart.
