### PR TITLE
fix(sanity-best-practices): use configured dataset in functions example

### DIFF
--- a/skills/sanity-best-practices/references/functions.md
+++ b/skills/sanity-best-practices/references/functions.md
@@ -573,7 +573,7 @@ If not using `@sanity/client`, implement lineage tracking manually:
 export const handler = documentEventHandler(async ({ context, event }) => {
   const lineage = process.env.X_SANITY_LINEAGE
 
-  await fetch(`https://${context.clientOptions.projectId}.api.sanity.io/v2025-05-08/data/mutate/production`, {
+  await fetch(`https://${context.clientOptions.projectId}.api.sanity.io/v2025-05-08/data/mutate/${context.clientOptions.dataset}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
# Description

## Summary

Updates the Sanity Functions documentation example for "Recursion control with custom HTTP clients" to use the active dataset from `context.clientOptions.dataset` instead of hardcoding `production`.

## Problem

The current example uses:

`/data/mutate/production`

That makes the example incorrect for any project using a non-`production` dataset. If copied as-is, the request can target the wrong dataset or fail unexpectedly.

## Fix

Replace the hardcoded dataset with:

`/data/mutate/${context.clientOptions.dataset}`

This keeps the example aligned with the function runtime context and makes it work across environments.

## Testing

Docs-only change.

Verified the example now references the active dataset from function context instead of a hardcoded dataset.

# Bug Report

If you find a security vulnerability, do NOT open an issue. Email [security@sanity.io](mailto:security@sanity.io) instead.

**Describe the bug**

The Sanity Functions example for "Recursion control with custom HTTP clients" hardcodes the dataset to `production` in the mutation URL. In non-`production` datasets, copying this example sends mutations to the wrong dataset.

**To Reproduce**

Steps to reproduce the behavior:

1. Open the Sanity Functions docs section for "Recursion control with custom HTTP clients".
2. Copy the example using `/data/mutate/production`.
3. Use it in a function running against a dataset like `staging`.
4. Trigger the function.
5. Observe that the request targets `production` instead of the active dataset.

**Expected behavior**

The example should use `context.clientOptions.dataset`, for example:

`/data/mutate/${context.clientOptions.dataset}`

**Screenshots**

N/A

**Which versions of Sanity are you using?**

I could not capture a verbatim `sanity versions` output in this environment because the CLI attempted a network lookup, but the local workspace is using:

- `sanity`: `5.31.1`
- `@sanity/functions`: `1.4.0`
- `@sanity/blueprints`: `0.15.2`
- `@sanity/client`: `7.24.0`
- `@sanity/cli`: `4.19.0`

**What operating system are you using?**

macOS 26.5.2 (Build 25F84) on Apple Silicon

**Which versions of Node.js / npm are you running?**

`10.9.2`

`v22.15.0`

**Additional context**

The current example uses:

`https://${context.clientOptions.projectId}.api.sanity.io/v2025-05-08/data/mutate/production`

It should use the dataset from `context.clientOptions.dataset` so the example works correctly across environments.

**Security issue?**

No. This is a documentation/example bug, not a security issue.
