### PR TITLE
fix/hydrogen-preview-session-docs 

### DIFF
--- a/skills/sanity-best-practices/references/hydrogen.md
+++ b/skills/sanity-best-practices/references/hydrogen.md
@@ -59,6 +59,8 @@ import {createSanityContext, type SanityContext} from 'hydrogen-sanity'
 import {PreviewSession} from 'hydrogen-sanity/preview/session'
 import {isPreviewEnabled} from 'hydrogen-sanity/preview'
 
+const previewSession = await PreviewSession.init(request, [env.SESSION_SECRET])
+
 const sanity = await createSanityContext({
   request,
   cache,
@@ -124,7 +126,7 @@ const PRODUCT_QUERY = defineQuery(`*[_type == "product" && store.slug.current ==
 
 // Loader
 export async function loader({params, context: {sanity}}: LoaderFunctionArgs) {
-  const initial = await context.sanity.query(PRODUCT_QUERY, params)
+  const initial = await sanity.query(PRODUCT_QUERY, params)
   return {initial}
 }
 


### PR DESCRIPTION
### Description

- Fix the Hydrogen `Context Setup` example in `skills/sanity-best-practices/references/hydrogen.md` by initializing a single `previewSession` before it is used.
- Reuse that same `previewSession` in both `isPreviewEnabled(...)` and `preview.session` so the example is internally consistent.
- Fix the loader example in the same file to use the destructured `sanity` variable directly when calling `query(...)`, while still passing `params` and returning `initial`.

### What to review

- Review `skills/sanity-best-practices/references/hydrogen.md` only.
- In the `Context Setup` example, confirm `previewSession` is initialized once before `createSanityContext(...)` and reused for both the `stega.enabled` check and `preview.session`.
- In the loader example, confirm the destructured `sanity` binding now matches the `sanity.query(PRODUCT_QUERY, params)` call and the example still returns `{initial}`.

### Testing

- No automated tests were added because this PR only updates documentation examples.
- Validated manually by reviewing the updated snippets against the current code in `hydrogen.md` to confirm both findings were still valid, the fixes are minimal, and the examples remain internally consistent.