### PR TITLE
feat: build and publish skills bundle to a Sanity dataset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           cache: npm
 
@@ -25,3 +25,32 @@ jobs:
 
       - name: Validate Cursor plugin
         run: npm run validate:cursor-plugin
+
+      - name: Build skills bundle
+        run: npm run build:bundle
+
+  publish-bundle:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build skills bundle
+        run: npm run build:bundle
+
+      - name: Publish bundle to Sanity
+        env:
+          SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
+          SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
+          SANITY_WRITE_TOKEN: ${{ secrets.SANITY_WRITE_TOKEN }}
+        run: node scripts/publish-skills-bundle.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-
 .DS_Store
 node_modules/
+skills-bundle.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "skills-ref": "^0.1.5"
+        "gray-matter": "^4.0.3",
+        "skills-ref": "0.1.5"
       }
     },
     "node_modules/argparse": {
@@ -29,6 +30,83 @@
         "node": ">=18"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -40,6 +118,30 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/skills-ref": {
@@ -57,6 +159,23 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "validate:pt-serialization": "skills-ref validate ./skills/portable-text-serialization",
     "validate:pt-conversion": "skills-ref validate ./skills/portable-text-conversion",
     "validate:cursor-plugin": "node scripts/validate-cursor-plugin.mjs",
-    "validate:all": "npm run validate && npm run validate:cursor-plugin"
+    "validate:all": "npm run validate && npm run validate:cursor-plugin",
+    "build:bundle": "node scripts/build-skills-bundle.mjs"
   },
   "devDependencies": {
+    "gray-matter": "^4.0.3",
     "skills-ref": "0.1.5"
   },
   "keywords": [

--- a/scripts/build-skills-bundle.mjs
+++ b/scripts/build-skills-bundle.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+/**
+ * Builds a single JSON bundle of all skills (SKILL.md + references) so
+ * consumers can fetch them from one place. Published to a Sanity dataset on
+ * every merge to main — see publish-skills-bundle.mjs and
+ * .github/workflows/ci.yml.
+ *
+ * Usage: node scripts/build-skills-bundle.mjs [output-path]
+ */
+
+import { execSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import matter from "gray-matter";
+
+const repoRoot = process.cwd();
+const skillsDir = path.join(repoRoot, "skills");
+const outputPath = path.resolve(repoRoot, process.argv[2] ?? "skills-bundle.json");
+
+const errors = [];
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getCommitSha() {
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA;
+  try {
+    return execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function loadSkill(skillDirName) {
+  const skillMdPath = path.join(skillsDir, skillDirName, "SKILL.md");
+  if (!(await pathExists(skillMdPath))) {
+    return null;
+  }
+
+  const fileContent = await fs.readFile(skillMdPath, "utf8");
+  const { data, content } = matter(fileContent);
+
+  if (!data.name) {
+    errors.push(`${skillDirName}/SKILL.md is missing "name" in frontmatter`);
+    return null;
+  }
+  if (!data.description) {
+    errors.push(`${skillDirName}/SKILL.md is missing "description" in frontmatter`);
+    return null;
+  }
+
+  const references = {};
+  const referencesDir = path.join(skillsDir, skillDirName, "references");
+  if (await pathExists(referencesDir)) {
+    const entries = await fs.readdir(referencesDir, { withFileTypes: true });
+    for (const entry of entries.filter((e) => e.isFile()).sort((a, b) => a.name.localeCompare(b.name))) {
+      const refContent = await fs.readFile(path.join(referencesDir, entry.name), "utf8");
+      const refName = entry.name.replace(/\.[^.]+$/, "");
+      if (refName in references) {
+        errors.push(`${skillDirName}/references has duplicate reference name "${refName}"`);
+      }
+      references[refName] = refContent;
+    }
+  }
+
+  return {
+    name: data.name,
+    description: data.description,
+    content: content.trim(),
+    references,
+  };
+}
+
+/**
+ * The references of sanity-best-practices double as standalone rules, so
+ * each must carry a description in its frontmatter.
+ */
+function validateRules(skill) {
+  for (const [name, markdown] of Object.entries(skill.references)) {
+    const { data, content } = matter(markdown);
+    if (!data.description || !String(data.description).trim()) {
+      errors.push(`sanity-best-practices/references/${name}.md is missing "description" in frontmatter`);
+    }
+    if (!content.trim()) {
+      errors.push(`sanity-best-practices/references/${name}.md has no content`);
+    }
+  }
+}
+
+const skillDirNames = (await fs.readdir(skillsDir, { withFileTypes: true }))
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+const skills = [];
+const seenNames = new Set();
+
+for (const skillDirName of skillDirNames) {
+  const skill = await loadSkill(skillDirName);
+  if (!skill) continue;
+
+  if (seenNames.has(skill.name)) {
+    errors.push(`Duplicate skill name "${skill.name}" (from ${skillDirName})`);
+    continue;
+  }
+  seenNames.add(skill.name);
+  skills.push(skill);
+}
+
+const sanityBestPractices = skills.find((skill) => skill.name === "sanity-best-practices");
+if (sanityBestPractices) {
+  validateRules(sanityBestPractices);
+} else {
+  errors.push('Required skill "sanity-best-practices" not found');
+}
+
+if (errors.length > 0) {
+  console.error("Skills bundle validation failed:");
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  process.exit(1);
+}
+
+const bundle = {
+  version: 1,
+  commit: getCommitSha(),
+  generatedAt: new Date().toISOString(),
+  skills,
+};
+
+await fs.writeFile(outputPath, `${JSON.stringify(bundle, null, 2)}\n`);
+console.log(`Wrote ${skills.length} skills to ${path.relative(repoRoot, outputPath)}`);

--- a/scripts/publish-skills-bundle.mjs
+++ b/scripts/publish-skills-bundle.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * Publishes skills-bundle.json (see build-skills-bundle.mjs) to a Sanity
+ * dataset as a single document, so consumers can fetch the latest skills
+ * from the Content Lake API without cloning the repo. Runs in CI on every
+ * merge to main — see .github/workflows/ci.yml.
+ *
+ * Requires SANITY_PROJECT_ID, SANITY_DATASET, and SANITY_WRITE_TOKEN.
+ *
+ * Usage: node scripts/publish-skills-bundle.mjs [bundle-path]
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const projectId = process.env.SANITY_PROJECT_ID;
+const dataset = process.env.SANITY_DATASET;
+const token = process.env.SANITY_WRITE_TOKEN;
+
+if (!projectId || !dataset || !token) {
+  console.error("SANITY_PROJECT_ID, SANITY_DATASET, and SANITY_WRITE_TOKEN must be set");
+  process.exit(1);
+}
+
+const bundlePath = path.resolve(process.cwd(), process.argv[2] ?? "skills-bundle.json");
+const bundle = JSON.parse(await fs.readFile(bundlePath, "utf8"));
+
+const document = {
+  _id: "skills-bundle",
+  _type: "skillsBundle",
+  version: bundle.version,
+  commit: bundle.commit,
+  generatedAt: bundle.generatedAt,
+  skills: bundle.skills.map((skill) => ({
+    _key: skill.name,
+    name: skill.name,
+    description: skill.description,
+    content: skill.content,
+    references: Object.entries(skill.references).map(([name, content]) => ({
+      _key: name,
+      name,
+      content,
+    })),
+  })),
+};
+
+const response = await fetch(
+  `https://${projectId}.api.sanity.io/v2025-02-19/data/mutate/${dataset}?visibility=sync`,
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ mutations: [{ createOrReplace: document }] }),
+  },
+);
+
+if (!response.ok) {
+  console.error(`Publish failed with HTTP ${response.status}: ${await response.text()}`);
+  process.exit(1);
+}
+
+const result = await response.json();
+console.log(
+  `Published skills bundle (commit: ${bundle.commit}, transaction: ${result.transactionId})`,
+);


### PR DESCRIPTION
Builds all skills into a single pre-validated JSON bundle and publishes it to a Sanity dataset on every merge to main, so consumers can fetch the latest skills from the Content Lake API instead of cloning the repo.

## What

- **`scripts/build-skills-bundle.mjs`** — parses every `skills/*/SKILL.md` plus its `references/` into `skills-bundle.json` (`npm run build:bundle`). The build fails on missing `name`/`description` frontmatter, duplicate skill names, or `sanity-best-practices` reference files without a `description`.
- **`scripts/publish-skills-bundle.mjs`** — writes the bundle to the configured Sanity dataset as a single `skills-bundle` document via the mutations API (`createOrReplace`, so each publish atomically replaces the previous one and document history provides rollback/audit).
- **CI (PRs + main):** builds the bundle as a check, so invalid skills can't merge.
- **CI (merge to main only):** publishes the bundle document. Reverting a skill change on main republishes automatically.
- GitHub Actions are pinned to commit SHAs.

## Configuration

Repo secrets: `SANITY_PROJECT_ID`, `SANITY_DATASET`, `SANITY_WRITE_TOKEN` (a token with write access to the dataset).

## Notes

- Bundle is ~376KB for the current 7 skills.
- Only `references/` directories are included alongside `SKILL.md`; the `rules/` dirs in the portable-text skills are not bundled.
- The document embeds the source `commit` and `generatedAt` timestamp; `references` maps are stored as `{name, content}` arrays to keep document keys well-formed.

## Test plan

- `npm run build:bundle` locally produces the expected 7 skills.
- Negative-tested: a skill missing `description` fails the build with exit 1.
- The publish step fails loudly if secrets are missing or the mutation is rejected; verified on the first merge to main once secrets are configured.