### PR TITLE
fix: publish usable getting-started sample content

### DIFF
--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -182,8 +182,20 @@ If migrating from another CMS or files:
 Ask the agent to draft structured sample content, then create it with the Sanity MCP Server:
 ```
 Tool: create_documents
-Documents: [{ type: "post", content: { title: "Getting started with Sanity", body: [] } }]
+Documents: [{
+  type: "post",
+  content: {
+    title: "Getting started with Sanity",
+    slug: { _type: "slug", current: "getting-started-with-sanity" },
+    body: []
+  }
+}]
 ```
+
+The content tool creates a draft. Show the draft to the user and ask whether to
+publish it so the public frontend can read it. If yes, call
+`publish_documents` with the returned document ID before starting frontend
+integration.
 
 **If MCP content tools cannot see new types or fields:** Remind them to run `npx sanity schemas deploy` first.
 


### PR DESCRIPTION
## What changed

The sample post now includes the slug required by the frontend query. The guide also makes the draft/publish boundary explicit before frontend integration.

## Why

`create_documents` creates a draft, and the previous sample had no slug. Even after a successful content step, the public frontend could not display the post until it was published.

## Validation

- Verified current MCP create and publish behavior
- `npm run validate:all`
- `git diff --check`
- Independent QA confirmed the slug matches the example schema and that content must be published before the public frontend can read it
- No live content write was performed for this documentation-only check

Related: [AIGRO-5299](https://linear.app/sanity/issue/AIGRO-5299/qa-the-getting-started-skill)
