### PR TITLE
fix: exercise client-side navigation in the Next.js smoke test

### DIFF
--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -260,6 +260,7 @@ export const client = createClient({
 // src/app/page.tsx
 import { client } from "@/sanity/client";
 import { defineQuery, type SanityDocument } from "next-sanity";
+import Link from "next/link";
 
 const POSTS_QUERY = defineQuery(
   `*[_type == "post" && defined(slug.current)] | order(_createdAt desc){ _id, title, slug }`
@@ -274,7 +275,7 @@ export default async function PostsPage() {
     <ul>
       {posts.map((post) => (
         <li key={post._id}>
-          <a href={`/${(post.slug as { current?: string })?.current}`}>{post.title as string}</a>
+          <Link href={`/${(post.slug as { current?: string })?.current}`}>{post.title as string}</Link>
         </li>
       ))}
     </ul>
@@ -340,7 +341,7 @@ Before declaring integration done, exercise both render paths:
 
 1. `npm run dev` (in the app folder)
 2. Load the home page (lists posts).
-3. **Click through to a detail page** via an in-app `<Link>` / `<a>` — do not paste the URL.
+3. **Click through to a detail page** via the in-app Next.js `<Link>` — do not paste the URL.
 4. Open the browser console. It should be clean. No `ReferenceError: process is not defined`, no hard reload to `/`.
 5. For good measure, reload the detail page directly (URL bar) — that exercises SSR.
 


### PR DESCRIPTION
## What changed

The Next.js example now renders post links with `next/link`, and the smoke test explicitly clicks that link.

## Why

A plain anchor triggers a document navigation, so the old smoke test did not exercise the client-side transition it claimed to test.

## Validation

- Isolated Next 16.3 / next-sanity 13.3 lint and production build
- `npm run validate:all`
- `git diff --check`
- Independent QA copied the example into a clean Next 16.3 / next-sanity 13.3.1 sandbox; lint and the production build passed

Related: [AIGRO-5299](https://linear.app/sanity/issue/AIGRO-5299/qa-the-getting-started-skill)
