### PR TITLE
fix: run schema deployment from the Studio directory

### DIFF
--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -96,7 +96,11 @@ export const post = defineType({
 
 **Required before Phase 2:**
 
+Run schema commands with the detected Studio folder as the working directory.
+For the default side-by-side layout:
+
 ```bash
+cd studio
 npx sanity schemas deploy
 ```
 


### PR DESCRIPTION
## What changed

The getting-started deploy step now changes into the standalone `studio/` directory before running `sanity schemas deploy`.

## Why

The scaffold is created under `studio/`, but the old command ran from the parent repo and failed with `No project root found`.

## Validation

- Reproduced the current CLI failure from a side-by-side repo root
- `npm run validate:all`
- `git diff --check`
- Independent QA reproduced `No project root found` from the parent directory and confirmed the command succeeds only with Studio project context

Related: [AIGRO-5299](https://linear.app/sanity/issue/AIGRO-5299/qa-the-getting-started-skill)
