### PR TITLE
fix: align the minimal Next.js fetch path

### DIFF
--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -251,7 +251,7 @@ export const client = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
   apiVersion: "2026-05-15", // Use current date for new projects
-  useCdn: false, // Use API directly for server-side rendering; set true for client-side reads
+  useCdn: true, // Fast, cached published-content reads
 });
 ```
 
@@ -282,7 +282,9 @@ export default async function PostsPage() {
 }
 ```
 
-`{ next: { revalidate: 30 } }` opts the fetch into Next.js' ISR cache with a 30-second revalidation window. Tune to taste; omit `options` to use defaults.
+`{ next: { revalidate: 30 } }` opts the fetch into Next.js' ISR cache with a
+30-second revalidation window. This is a minimal published-content path for a
+first smoke test. Tune to taste; omit `options` to use defaults.
 
 **Render an individual post (`src/app/[slug]/page.tsx`):**
 ```typescript
@@ -321,7 +323,11 @@ NEXT_PUBLIC_SANITY_PROJECT_ID=your-project-id
 NEXT_PUBLIC_SANITY_DATASET=production
 ```
 
-For advanced patterns (TypeGen, Visual Editing with `next-sanity/visual-editing`, live content with `defineLive` from `next-sanity/live`, standalone Studio architecture), see `nextjs.md`.
+After the first smoke test, configure TypeGen and replace the broad
+`SanityDocument` casts with generated query results. Run TypeGen after schema
+or query changes. For the recommended production path—live content with
+`defineLive`, Visual Editing, and the standalone Studio architecture—follow
+`nextjs.md`.
 
 ### Step 3: Other Frameworks
 


### PR DESCRIPTION
## What changed

The minimal published-content client now uses the CDN and clearly separates the first ISR smoke test from the recommended production `defineLive` path.

The guide also tells the agent to configure TypeGen and replace broad `SanityDocument` casts after the smoke test. This focused PR does not add the full monorepo TypeGen configuration; that remains in the dedicated TypeGen guidance.

## Why

The old inline recipe contradicted the adjacent Next.js guidance by bypassing the CDN without a freshness requirement and presenting manual ISR as the general recommendation.

## Validation

- Verified current Sanity Next.js client and caching guidance
- Isolated Next 16.3 / next-sanity 13.3 lint and production build
- `npm run validate:all`
- `git diff --check`
- Independent QA copied the example into an isolated Next 16.3 / next-sanity 13.3.1 sandbox; lint and the production build passed
- Reviewer scope note: this PR points to TypeGen but intentionally does not add the full monorepo TypeGen configuration

Related: [AIGRO-5299](https://linear.app/sanity/issue/AIGRO-5299/qa-the-getting-started-skill)
