### PR TITLE
fix: register the getting-started post schema

### DIFF
--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -92,6 +92,18 @@ export const post = defineType({
 })
 ```
 
+Register the type in the schema entry point:
+```typescript
+// schemaTypes/index.ts
+import { post } from './post'
+
+export const schemaTypes = [post]
+```
+
+Creating the file is not enough. Only types included in the array passed to
+`schema.types` are part of the Studio schema and available to schema
+deployment.
+
 ### Step 3: Deploy Schema
 
 **Required before Phase 2:**


### PR DESCRIPTION
## What changed

The example now imports `post` in `schemaTypes/index.ts` and adds it to the exported `schemaTypes` array.

## Why

Creating `schemaTypes/post.ts` alone does not register the type, so schema deployment and MCP content tools could not see it.

## Validation

- Verified against the current clean Studio template
- `npm run validate:all`
- `git diff --check`
- Independent QA confirmed the type is unavailable until it is included in the exported array passed to `schema.types`

Related: [AIGRO-5299](https://linear.app/sanity/issue/AIGRO-5299/qa-the-getting-started-skill)
