### PR TITLE
fix: make the API version placeholder explicit

### DIFF
--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -250,7 +250,7 @@ import { createClient } from "next-sanity";
 export const client = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
-  apiVersion: "2026-05-15", // Use current date for new projects
+  apiVersion: "YYYY-MM-DD", // Replace with today's UTC date and keep it hard-coded
   useCdn: false, // Use API directly for server-side rendering; set true for client-side reads
 });
 ```


### PR DESCRIPTION
## What changed

The Next.js client example now uses an explicit `YYYY-MM-DD` placeholder and tells the agent to replace it with today's UTC date while keeping the result hard-coded.

## Why

The previous example claimed to use the current date but embedded an already stale date. A dynamic date would remove API-version stability, so replacement at generation time is the safe path.

## Validation

- Confirmed current API-version guidance
- Confirmed placeholder replacement passes client validation
- `npm run validate:all`
- `git diff --check`
- Independent QA confirmed the literal placeholder fails client validation until replaced, while `2026-08-04` succeeds and remains pinned

Related: [AIGRO-5299](https://linear.app/sanity/issue/AIGRO-5299/qa-the-getting-started-skill)
