### PR TITLE
fix: import defineLive from next-sanity/live

### DIFF
--- a/skills/sanity-best-practices/references/nextjs.md
+++ b/skills/sanity-best-practices/references/nextjs.md
@@ -54,7 +54,7 @@ We use `defineLive` (next-sanity v11+) to enable real-time content updates and V
 ### Setup (`src/sanity/lib/live.ts`)
 
 ```typescript
-import { defineLive } from 'next-sanity'
+import { defineLive } from 'next-sanity/live'
 import { client } from './client'
 
 export const { sanityFetch, SanityLive } = defineLive({


### PR DESCRIPTION
## What changed

The Next.js guide now imports `defineLive` from `next-sanity/live`.

## Why

Current `next-sanity` does not export `defineLive` from its package root. The documented import fails, while the dedicated live entrypoint is available in supported versions.

## Validation

- Focused export check against `next-sanity@13.3.1`
- Confirmed the subpath in v11 and v12
- `npm run validate:all`
- `git diff --check`
- Independent QA confirmed `next-sanity@13.3.1` has no root `defineLive` export and that `next-sanity/live` does export it

Related: [AIGRO-5299](https://linear.app/sanity/issue/AIGRO-5299/qa-the-getting-started-skill)
