### PR TITLE
fix: document unattended Studio setup

### DIFF
--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -55,10 +55,21 @@ Resume from where they left off.
 
 **If NO Studio found:**
 - Ask: "Want to create a new Sanity Studio?"
-- If yes, run from the repo root — **not inside a Next.js app folder**, where the CLI would switch to its embedded flow (not recommended):
+- If yes, first run `node --version`. Current Sanity Studio and CLI releases
+  require Node.js 22.12 or newer.
+- Create or select the project and dataset first. Prefer Sanity MCP project
+  tools when available, and never guess an organization or create a project in
+  the wrong account.
+- Run the initializer unattended with the known values from the repo root —
+  **not inside a Next.js app folder**, where the CLI would switch to its
+  embedded flow (not recommended):
   ```bash
-  npm create sanity@latest -- --template clean --typescript --output-path studio
+  npm create sanity@latest -- --yes --project <projectId> --dataset <dataset> --template clean --typescript --output-path studio
   ```
+- If the CLI reports missing authentication, ask the user to authenticate,
+  then retry the same unattended command. If a project, organization, or
+  dataset choice is still missing, ask the user to provide it. Do not fall back
+  to an interactive initializer flow.
 - This creates a standalone Studio in `studio/`, alongside your app folder (see `project-structure.md`)
 
 **If Studio exists:**


### PR DESCRIPTION
## What changed

The Studio setup step now checks the Node.js floor and gives agents one deterministic path: select or create the project and dataset first, then run the initializer unattended with explicit `--yes`, `--project`, and `--dataset` values.

Missing authentication or account choices are treated as a user handoff before retrying the same unattended command, not as a second interactive scaffolding flow.

## Why

Current agent terminals can be detected as unattended. The old command then failed because the CLI had no project or organization context. Keeping one agent-native path also avoids hanging on prompts or creating a project in the wrong account.

This revision incorporates review feedback to remove the interactive initializer recommendation.

## Validation

- Rebased onto current `main`
- Checked current `sanity`, `create-sanity`, and CLI engine requirements
- Checked live initializer help and unattended behavior
- `npm run validate:all`
- `git diff --check`
- Independent QA reproduced the original unattended failure under `TERM=dumb`

Related: [AIGRO-5299](https://linear.app/sanity/issue/AIGRO-5299/qa-the-getting-started-skill)
