### PR TITLE
Fix remaining getting-started pilot gaps

### DIFF
--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -109,11 +109,16 @@ Check whether Sanity MCP tools are already available before creating files.
 - Show them what you found
 - Ask: "Want to add more content types or modify existing ones?"
 
+Before moving to Phase 2, keep track of the primary document type and the
+fields needed to list and render it. Carry that choice through content checks,
+sample content, queries, routes, and components. Never fall back to `post`
+unless the registered primary type is actually `post`.
+
 **If they want a quick example:**
 Create a basic blog schema:
 ```typescript
 // schemaTypes/post.ts
-import { defineType, defineField } from 'sanity'
+import { defineArrayMember, defineField, defineType } from 'sanity'
 
 export const post = defineType({
   name: 'post',
@@ -122,7 +127,11 @@ export const post = defineType({
   fields: [
     defineField({ name: 'title', type: 'string' }),
     defineField({ name: 'slug', type: 'slug', options: { source: 'title' } }),
-    defineField({ name: 'body', type: 'array', of: [{ type: 'block' }] }),
+    defineField({
+      name: 'body',
+      type: 'array',
+      of: [defineArrayMember({ type: 'block' })],
+    }),
   ],
 })
 ```
@@ -161,8 +170,11 @@ This uploads your schema to the Content Lake so MCP tools can work with it.
 
 **Use MCP `query_documents` to check:**
 ```
-*[_type == "post"][0...5]
+*[_type == "<primaryDocumentType>"][0...5]
 ```
+
+Replace `<primaryDocumentType>` with the registered type selected in Phase 1,
+such as `post`, `product`, or `project`.
 
 **If content exists:**
 - Show them a summary
@@ -182,7 +194,10 @@ If migrating from another CMS or files:
 
 ### Step 2b: Generate Sample Content (MCP)
 
-Ask the agent to draft structured sample content, then create it with the Sanity MCP Server:
+Ask the agent to draft structured sample content that matches the selected
+primary document type, then create it with the Sanity MCP Server.
+
+For the quick blog example above:
 ```
 Tool: create_documents
 Documents: [{
@@ -198,7 +213,7 @@ Documents: [{
 The content tool creates a draft. Show the draft to the user and ask whether to
 publish it so the public frontend can read it. If yes, call
 `publish_documents` with the returned document ID, then use
-`query_documents` to confirm the post is visible from the published
+`query_documents` to confirm the document is visible from the published
 perspective before starting frontend integration.
 
 **If MCP content tools cannot see new types or fields:** Remind them to run `npx sanity schemas deploy` first.
@@ -295,6 +310,12 @@ The working directory is often a parent folder with the Studio and the app side 
 ### Step 2: Next.js Integration (Inline)
 
 If Next.js is detected, follow these essential steps:
+
+The inline implementation below continues the quick **Blog** example. If the
+primary document type is not `post`, adapt the type filter, projection, sample
+document, route, component names, and renderer to the fields selected in Phase
+1. Do not create or query `post` as a fallback for E-commerce or Portfolio
+setups.
 
 **Scaffold a new app (if you don't have one yet):**
 
@@ -402,11 +423,40 @@ NEXT_PUBLIC_SANITY_PROJECT_ID=your-project-id
 NEXT_PUBLIC_SANITY_DATASET=production
 ```
 
-After the first smoke test, configure TypeGen and replace the broad
-`SanityDocument` casts with generated query results. Run TypeGen after schema
-or query changes. For the recommended production path—live content with
-`defineLive`, Visual Editing, and the standalone Studio architecture—follow
-`nextjs.md`.
+**Configure TypeGen before calling the Next.js setup complete:**
+
+Merge the TypeGen settings into the existing `studio/sanity.cli.ts`. For the
+side-by-side `studio/` and `web/` layout:
+
+```typescript
+typegen: {
+  enabled: true,
+  path: '../web/src/**/*.{ts,tsx,js,jsx}',
+  schema: 'schema.json',
+  generates: '../web/sanity.types.ts',
+  overloadClientMethods: true,
+},
+```
+
+Add a repeatable script to `studio/package.json`:
+
+```json
+"typegen": "sanity schemas extract --force && sanity typegen generate"
+```
+
+Then run it from the Studio folder:
+
+```bash
+cd studio
+npm run typegen
+```
+
+Confirm TypeGen found the frontend queries, then remove the `SanityDocument`
+import, broad generic arguments, and casts. Run TypeGen after schema or query
+changes. For other layouts, use `typegen.md` to adjust the paths.
+
+For the recommended production path—live content with `defineLive`, Visual
+Editing, and the standalone Studio architecture—follow `nextjs.md`.
 
 ### Step 3: Other Frameworks
 
@@ -424,7 +474,7 @@ Each rule file contains framework-specific patterns for data fetching, Portable 
 Before declaring integration done, exercise both render paths:
 
 1. `npm run dev` (in the app folder)
-2. Load the home page (lists posts).
+2. Load the home page (lists the selected content type).
 3. **Click through to a detail page** via the in-app Next.js `<Link>` — do not paste the URL.
 4. Open the browser console. It should be clean. No `ReferenceError: process is not defined`, no hard reload to `/`.
 5. For good measure, reload the detail page directly (URL bar) — that exercises SSR.
@@ -473,7 +523,7 @@ npx sanity dev                   # Start Studio locally
 npx sanity schemas deploy         # Deploy schema for MCP/editor access
 npx sanity deploy                # Deploy Studio to Sanity hosting
 npx sanity manage                # Open project settings
-npm run typegen                  # Generate TypeScript types
+npm run typegen                  # Generate types (run in Studio after adding the script above)
 ```
 
 ---

--- a/skills/sanity-best-practices/references/typegen.md
+++ b/skills/sanity-best-practices/references/typegen.md
@@ -29,7 +29,7 @@ Run the extract + generate cycle whenever schema or queries change:
 2.  **Generate:** Scans your codebase for GROQ queries and generates TypeScript types.
 
 ```bash
-npx sanity schemas extract && npx sanity typegen generate
+npx sanity schemas extract --force && npx sanity typegen generate
 ```
 
 ### Watch Mode (for separate frontends)
@@ -45,7 +45,7 @@ For manual workflows, implement a single script:
 **package.json:**
 ```json
 "scripts": {
-  "typegen": "sanity schemas extract && sanity typegen generate"
+  "typegen": "sanity schemas extract --force && sanity typegen generate"
 }
 ```
 
@@ -136,9 +136,9 @@ import { defineQuery } from "groq";
 
 const AUTHOR_QUERY = defineQuery(`*[_type == "author" && slug.current == $slug][0]{ name, bio }`);
 
-import type { AUTHOR_QUERYResult } from "@/sanity.types";
+import type { AUTHOR_QUERY_RESULT } from "@/sanity.types";
 
-export default function Author({ data }: { data: AUTHOR_QUERYResult }) {
+export default function Author({ data }: { data: AUTHOR_QUERY_RESULT }) {
   return <h1>{data.name}</h1>
 }
 ```
@@ -147,7 +147,7 @@ export default function Author({ data }: { data: AUTHOR_QUERYResult }) {
 Use `--enforce-required-fields` during extraction to translate `validation: rule => rule.required()` into non-optional types:
 
 ```bash
-npx sanity schemas extract --enforce-required-fields
+npx sanity schemas extract --force --enforce-required-fields
 npx sanity typegen generate
 ```
 


### PR DESCRIPTION
## Summary

This is the consolidated fast-follow to #68 through #77.

- Carry the selected primary document type through content checks and frontend integration instead of silently falling back to `post`.
- Make the quick blog schema follow the skill's `defineArrayMember` rule.
- Add a concrete side-by-side TypeGen setup to the getting-started flow.
- Make schema extraction repeatable with `--force`.
- Correct the generated query-result type naming example.

> [!NOTE]
> The `AUTHOR_QUERY_RESULT` change is intentional for Sanity v5+. TypeGen now matches the result suffix to the query identifier's casing: `PAGE_QUERYResult` was the v4 output, while SCREAMING_SNAKE_CASE queries generate `PAGE_QUERY_RESULT` in v5 and later. See the [Sanity v5 TypeGen casing changelog](https://www.sanity.io/docs/changelog/fd3ab62e-9264-4e7b-825a-fd4f99abd481#typegen-preserves-query_name_casing-breaking-change).

## Merge order

This PR is intended to fast-follow #68–#77. It temporarily targets the combined integration branch so the diff contains only these follow-up fixes and can be tested against all ten predecessors together. Once #68–#77 land, retarget/rebase this PR onto `main`.

The held upstream `next-sanity` dependency issue is out of scope. The separate CLI help-text drift around `sanity-typegen.json` also belongs upstream and is not changed here.

## Why

A clean end-to-end pilot found that E-commerce and Portfolio choices still fell into a Blog-only `post` flow. It also found that a clean Studio has no `npm run typegen` script, the documented script failed on its second run because `schema.json` already existed, and one manual generated-type example used the wrong alias shape.

## Validation

Repository checks:

- `npm run validate:all`
- `git diff --check`

Independent clean e-commerce pilot:

- Side-by-side standalone Studio and Next.js app with `product` as the sole custom document.
- Initial TypeGen run succeeded and found 1 query / 12 schema types.
- After adding an optional schema/query field, the second run succeeded with the same discovery counts.
- A third repeated run produced byte-identical `schema.json` and `sanity.types.ts`.
- Sanity schema validation: 0 errors, 0 warnings.
- Studio TypeScript check and production build passed.
- Next.js lint, typecheck, and production build passed.
- No live Sanity project, dataset, schema, content, CORS, or deployment writes were made.
