### PR TITLE
fix: integrate remaining getting-started updates

### DIFF
--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -106,6 +106,11 @@ Check whether Sanity MCP tools are already available before creating files.
 - Show them what you found
 - Ask: "Want to add more content types or modify existing ones?"
 
+Before moving to Phase 2, keep track of the primary document type and the
+fields needed to list and render it. Carry that choice through content checks,
+sample content, queries, routes, and components. Never fall back to `post`
+unless the registered primary type is actually `post`.
+
 **If they want a quick example:**
 Create a basic blog schema:
 ```typescript
@@ -158,8 +163,11 @@ This uploads your schema to the Content Lake so MCP tools can work with it.
 
 **Use MCP `query_documents` to check:**
 ```
-*[_type == "post"][0...5]
+*[_type == "<primaryDocumentType>"][0...5]
 ```
+
+Replace `<primaryDocumentType>` with the registered type selected in Phase 1,
+such as `post`, `product`, or `project`.
 
 **If content exists:**
 - Show them a summary
@@ -179,7 +187,10 @@ If migrating from another CMS or files:
 
 ### Step 2b: Generate Sample Content (MCP)
 
-Ask the agent to draft structured sample content, then create it with the Sanity MCP Server:
+Ask the agent to draft structured sample content that matches the selected
+primary document type, then create it with the Sanity MCP Server.
+
+For the quick blog example above:
 ```
 Tool: create_documents
 Documents: [{
@@ -285,6 +296,12 @@ The working directory is often a parent folder with the Studio and the app side 
 ### Step 2: Next.js Integration (Inline)
 
 If Next.js is detected, follow these essential steps:
+
+The inline implementation below continues the quick **Blog** example. If the
+primary document type is not `post`, adapt the type filter, projection, sample
+document, route, component names, and renderer to the fields selected in Phase
+1. Do not create or query `post` as a fallback for E-commerce or Portfolio
+setups.
 
 **Scaffold a new app (if you don't have one yet):**
 
@@ -414,7 +431,7 @@ Each rule file contains framework-specific patterns for data fetching, Portable 
 Before declaring integration done, exercise both render paths:
 
 1. `npm run dev` (in the app folder)
-2. Load the home page (lists posts).
+2. Load the home page (lists the selected content type).
 3. **Click through to a detail page** via the in-app Next.js `<Link>` — do not paste the URL.
 4. Open the browser console. It should be clean. No `ReferenceError: process is not defined`, no hard reload to `/`.
 5. For good measure, reload the detail page directly (URL bar) — that exercises SSR.

--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -413,11 +413,40 @@ NEXT_PUBLIC_SANITY_PROJECT_ID=your-project-id
 NEXT_PUBLIC_SANITY_DATASET=production
 ```
 
-After the first smoke test, configure TypeGen and replace the broad
-`SanityDocument` casts with generated query results. Run TypeGen after schema
-or query changes. For the recommended production path—live content with
-`defineLive`, Visual Editing, and the standalone Studio architecture—follow
-`nextjs.md`.
+**Configure TypeGen before calling the Next.js setup complete:**
+
+Merge the TypeGen settings into the existing `studio/sanity.cli.ts`. For the
+side-by-side `studio/` and `web/` layout:
+
+```typescript
+typegen: {
+  enabled: true,
+  path: '../web/src/**/*.{ts,tsx,js,jsx}',
+  schema: 'schema.json',
+  generates: '../web/sanity.types.ts',
+  overloadClientMethods: true,
+},
+```
+
+Add a repeatable script to `studio/package.json`:
+
+```json
+"typegen": "sanity schemas extract --force && sanity typegen generate"
+```
+
+Then run it from the Studio folder:
+
+```bash
+cd studio
+npm run typegen
+```
+
+Confirm TypeGen found the frontend queries, then remove the `SanityDocument`
+import, broad generic arguments, and casts. Run TypeGen after schema or query
+changes. For other layouts, use `typegen.md` to adjust the paths.
+
+For the recommended production path—live content with `defineLive`, Visual
+Editing, and the standalone Studio architecture—follow `nextjs.md`.
 
 ### Step 3: Other Frameworks
 
@@ -484,7 +513,7 @@ npx sanity dev                   # Start Studio locally
 npx sanity schemas deploy         # Deploy schema for MCP/editor access
 npx sanity deploy                # Deploy Studio to Sanity hosting
 npx sanity manage                # Open project settings
-npm run typegen                  # Generate TypeScript types
+npm run typegen                  # Generate types (run in Studio after adding the script above)
 ```
 
 ---

--- a/skills/sanity-best-practices/references/get-started.md
+++ b/skills/sanity-best-practices/references/get-started.md
@@ -115,7 +115,7 @@ unless the registered primary type is actually `post`.
 Create a basic blog schema:
 ```typescript
 // schemaTypes/post.ts
-import { defineType, defineField } from 'sanity'
+import { defineArrayMember, defineField, defineType } from 'sanity'
 
 export const post = defineType({
   name: 'post',
@@ -124,7 +124,11 @@ export const post = defineType({
   fields: [
     defineField({ name: 'title', type: 'string' }),
     defineField({ name: 'slug', type: 'slug', options: { source: 'title' } }),
-    defineField({ name: 'body', type: 'array', of: [{ type: 'block' }] }),
+    defineField({
+      name: 'body',
+      type: 'array',
+      of: [defineArrayMember({ type: 'block' })],
+    }),
   ],
 })
 ```

--- a/skills/sanity-best-practices/references/typegen.md
+++ b/skills/sanity-best-practices/references/typegen.md
@@ -29,7 +29,7 @@ Run the extract + generate cycle whenever schema or queries change:
 2.  **Generate:** Scans your codebase for GROQ queries and generates TypeScript types.
 
 ```bash
-npx sanity schemas extract && npx sanity typegen generate
+npx sanity schemas extract --force && npx sanity typegen generate
 ```
 
 ### Watch Mode (for separate frontends)
@@ -45,7 +45,7 @@ For manual workflows, implement a single script:
 **package.json:**
 ```json
 "scripts": {
-  "typegen": "sanity schemas extract && sanity typegen generate"
+  "typegen": "sanity schemas extract --force && sanity typegen generate"
 }
 ```
 
@@ -147,7 +147,7 @@ export default function Author({ data }: { data: AUTHOR_QUERYResult }) {
 Use `--enforce-required-fields` during extraction to translate `validation: rule => rule.required()` into non-optional types:
 
 ```bash
-npx sanity schemas extract --enforce-required-fields
+npx sanity schemas extract --force --enforce-required-fields
 npx sanity typegen generate
 ```
 

--- a/skills/sanity-best-practices/references/typegen.md
+++ b/skills/sanity-best-practices/references/typegen.md
@@ -136,9 +136,9 @@ import { defineQuery } from "groq";
 
 const AUTHOR_QUERY = defineQuery(`*[_type == "author" && slug.current == $slug][0]{ name, bio }`);
 
-import type { AUTHOR_QUERYResult } from "@/sanity.types";
+import type { AUTHOR_QUERY_RESULT } from "@/sanity.types";
 
-export default function Author({ data }: { data: AUTHOR_QUERYResult }) {
+export default function Author({ data }: { data: AUTHOR_QUERY_RESULT }) {
   return <h1>{data.name}</h1>
 }
 ```


### PR DESCRIPTION
## Description

Cleans up remaining `getting-started` inconsistencies. Fixes [AIGRO-5299](https://linear.app/sanity/issue/AIGRO-5299/qa-the-getting-started-skill)

- Carry the selected document type through onboarding instead of falling back to the Blog example.
- Use `defineArrayMember` for inline array members.
- Make TypeGen concrete and repeatable, including the v5 `_RESULT` alias casing.

## Testing

- `npm run validate:all`
- `git diff --check`
- Fresh Studio + Next.js e-commerce pilot: schema validation, Studio and Next.js checks/builds, two identical TypeGen runs, and browser list → detail → reload all passed.
